### PR TITLE
Implement Supabase server client helper with cookie propagation

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -19,19 +19,14 @@ export async function POST(req: Request) {
   const origin = req.headers.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "";
   const redirectTo = `${origin.replace(/\/$/, "")}/reinitialiser-mot-de-passe`;
 
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
+
   try {
-    const supabase = createServerClient(url, anon, {
-      cookies: {
-        get: () => undefined,
-        set: () => {},
-        remove: () => {},
-      },
-    });
     const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo } as any);
     if (error) throw error;
   } catch {
-    return NextResponse.json({ error: "send-failed" }, { status: 200 });
+    return applyServerCookies(NextResponse.json({ error: "send-failed" }, { status: 200 }));
   }
 
-  return NextResponse.json({ ok: true }, { status: 200 });
+  return applyServerCookies(NextResponse.json({ ok: true }, { status: 200 }));
 }

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,42 +1,30 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-
-  const storeMaybe: any = (cookies as any)();
-  const jar = typeof storeMaybe?.then === "function" ? await storeMaybe : storeMaybe;
-
-  const supabase = createServerClient(URL, ANON, {
-    cookies: {
-      getAll() {
-        return jar.getAll();
-      },
-      setAll(_list) {},
-    },
-  });
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
 
   const {
     data: { session },
   } = await supabase.auth.getSession();
 
   if (!session) {
-    return NextResponse.json({ session: null }, { status: 200 });
+    return applyServerCookies(NextResponse.json({ session: null }, { status: 200 }));
   }
 
-  return NextResponse.json(
-    {
-      session: {
-        access_token: session.access_token,
-        refresh_token: session.refresh_token,
-        user: session.user,
+  return applyServerCookies(
+    NextResponse.json(
+      {
+        session: {
+          access_token: session.access_token,
+          refresh_token: session.refresh_token,
+          user: session.user,
+        },
       },
-    },
-    { status: 200 }
+      { status: 200 }
+    )
   );
 }

--- a/src/app/api/email/resend/route.ts
+++ b/src/app/api/email/resend/route.ts
@@ -1,41 +1,24 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { sendVerificationEmail } from "@/lib/email/verifyEmail";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST() {
-  const response = new NextResponse();
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
 
   try {
     const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
     const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-    const storeMaybe: any = (cookies as any)();
-    const cookieStore = typeof storeMaybe?.then === "function" ? await storeMaybe : storeMaybe;
-
-    const supabase = createServerClient(URL, ANON, {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string) {
-          cookieStore.delete(name);
-        },
-      },
-    });
 
     const { data: { user }, error } = await supabase.auth.getUser();
     if (error || !user?.email) {
-      return NextResponse.json({ ok: false, error: "not_authenticated" }, { status: 401, headers: response.headers });
+      return applyServerCookies(
+        NextResponse.json({ ok: false, error: "not_authenticated" }, { status: 401 })
+      );
     }
 
     const admin = createAdminClient(URL, SERVICE, { auth: { persistSession: false, autoRefreshToken: false } });
@@ -47,15 +30,19 @@ export async function POST() {
       .from("email_verification_tokens")
       .upsert({ user_id: user.id, token, expires_at: grace }, { onConflict: "user_id" });
     if (upErr) {
-      return NextResponse.json({ ok: false, error: upErr.message }, { status: 500, headers: response.headers });
+      return applyServerCookies(
+        NextResponse.json({ ok: false, error: upErr.message }, { status: 500 })
+      );
     }
 
     await admin.from("profiles").update({ grace_expires_at: grace }).eq("id", user.id);
 
     await sendVerificationEmail({ email: user.email, token });
 
-    return NextResponse.json({ ok: true, sent: true }, { headers: response.headers });
+    return applyServerCookies(NextResponse.json({ ok: true, sent: true }));
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+    return applyServerCookies(
+      NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 })
+    );
   }
 }

--- a/src/app/deconnexion/route.ts
+++ b/src/app/deconnexion/route.ts
@@ -1,28 +1,19 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export async function GET(req: Request) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  const jar = await cookies();
-
   const res = NextResponse.redirect(new URL("/connexion", req.url), 302);
   res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
   res.headers.set("Pragma", "no-cache");
   res.headers.set("Clear-Site-Data", `"storage"`);
 
-  const supabase = createServerClient(url, anon, {
-    cookies: {
-      get(n: string) { return jar.get(n)?.value; },
-      set(n: string, v: string, o: CookieOptions) { res.cookies.set({ name: n, value: v, ...o, path: "/" }); },
-      remove(n: string, o: CookieOptions) { res.cookies.set({ name: n, value: "", ...o, path: "/", maxAge: 0 }); },
-    },
-  });
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
+  const jar = await cookies();
 
   try { await supabase.auth.signOut({ scope: "global" }); } catch {}
 
@@ -35,5 +26,5 @@ export async function GET(req: Request) {
     }
   }
 
-  return res;
+  return applyServerCookies(res);
 }

--- a/src/app/entrainements/layout.tsx
+++ b/src/app/entrainements/layout.tsx
@@ -1,7 +1,6 @@
 // src/app/compte/layout.tsx
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerClient } from "@supabase/ssr";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
@@ -10,27 +9,17 @@ export default async function CompteLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
 
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
+    applyServerCookies();
     redirect("/connexion");
   }
 
+  applyServerCookies();
   return <>{children}</>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,21 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerClient } from "@supabase/ssr";
 import HeroConcept from "@/components/HeroConcept";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
+  const { supabase, applyServerCookies } = await createServerSupabaseClient();
 
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (user) {
+    applyServerCookies();
     redirect("/entrainements");
   }
 
+  applyServerCookies();
   return <HeroConcept />;
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,20 +1,97 @@
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { cookies as nextCookies } from "next/headers";
+import { NextResponse } from "next/server";
+import {
+  MutableRequestCookiesAdapter,
+  appendMutableCookies,
+  getModifiedCookieValues,
+} from "next/dist/server/web/spec-extension/adapters/request-cookies";
+import {
+  ResponseCookies,
+  stringifyCookie,
+} from "next/dist/server/web/spec-extension/cookies";
+import { requestAsyncStorage } from "next/dist/server/async-storage/request-async-storage.external";
+import { synchronizeMutableCookies } from "next/dist/server/async-storage/request-store";
 
-export function createClient() {
-  const cookieStore = cookies() as unknown as ReadonlyMap<string, { value: string }>;
+type SupabaseServerClientResult<Database> = {
+  supabase: SupabaseClient<Database>;
+  applyServerCookies: {
+    (): void;
+    (response: NextResponse): NextResponse;
+  };
+  getSetCookieStrings: () => string[];
+};
 
-  return createServerClient(
+function normalizeOptions(options?: CookieOptions): CookieOptions {
+  if (!options) return {};
+  const { name: _name, ...rest } = options;
+  return rest;
+}
+
+async function resolveCookiesStore(): Promise<ReturnType<typeof nextCookies>> {
+  const storeMaybe = (nextCookies as unknown as () => unknown)();
+  if (typeof (storeMaybe as Promise<unknown>)?.then === "function") {
+    return (storeMaybe as Promise<ReturnType<typeof nextCookies>>);
+  }
+  return storeMaybe as ReturnType<typeof nextCookies>;
+}
+
+export async function createServerSupabaseClient<Database = unknown>(): Promise<
+  SupabaseServerClientResult<Database>
+> {
+  const cookieStore = await resolveCookiesStore();
+  const requestStore = requestAsyncStorage.getStore?.();
+
+  const mutableCookies = (requestStore?.mutableCookies ??
+    MutableRequestCookiesAdapter.wrap(cookieStore as any)) as ResponseCookies;
+
+  const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
+        async getAll() {
+          return mutableCookies.getAll().map(({ name, value }) => ({ name, value }));
         },
-        set() {},
-        remove() {},
+        async setAll(cookies) {
+          for (const cookie of cookies) {
+            const normalized = normalizeOptions(cookie.options);
+            mutableCookies.set({ name: cookie.name, value: cookie.value, ...normalized });
+          }
+        },
       },
     }
   );
+
+  function applyServerCookies(): void;
+  function applyServerCookies(response: NextResponse): NextResponse;
+  function applyServerCookies(response?: NextResponse) {
+    if (!mutableCookies) {
+      return response;
+    }
+
+    if (response) {
+      appendMutableCookies(response.headers, mutableCookies);
+      return response;
+    }
+
+    if (requestStore) {
+      synchronizeMutableCookies(requestStore);
+    }
+
+    return undefined;
+  }
+
+  function getSetCookieStrings() {
+    const modified = getModifiedCookieValues(mutableCookies);
+    if (!modified.length) return [];
+    return modified.map((cookie) => stringifyCookie(cookie));
+  }
+
+  return {
+    supabase,
+    applyServerCookies,
+    getSetCookieStrings,
+  };
 }


### PR DESCRIPTION
## Summary
- add a reusable `createServerSupabaseClient` helper that wraps Supabase cookies and exposes apply helpers
- refactor layouts, guards, and Supabase-backed routes to use the helper and forward `Set-Cookie` headers
- ensure auth flows (session refresh, logout, callbacks) apply the refreshed cookie mutations consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a82cb558832eaba56dd833fc72e2