### PR TITLE
Ensure session endpoint forwards refreshed Supabase cookies

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -9,6 +9,7 @@ export async function GET() {
   const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
+  const response = new NextResponse();
   const storeMaybe: any = (cookies as any)();
   const jar = typeof storeMaybe?.then === "function" ? await storeMaybe : storeMaybe;
 
@@ -17,7 +18,11 @@ export async function GET() {
       getAll() {
         return jar.getAll();
       },
-      setAll(_list) {},
+      setAll(cookies) {
+        cookies.forEach(({ name, value, options }) => {
+          response.cookies.set({ name, value, ...options });
+        });
+      },
     },
   });
 
@@ -26,7 +31,10 @@ export async function GET() {
   } = await supabase.auth.getSession();
 
   if (!session) {
-    return NextResponse.json({ session: null }, { status: 200 });
+    return NextResponse.json(
+      { session: null },
+      { status: 200, headers: response.headers }
+    );
   }
 
   return NextResponse.json(
@@ -37,6 +45,6 @@ export async function GET() {
         user: session.user,
       },
     },
-    { status: 200 }
+    { status: 200, headers: response.headers }
   );
 }


### PR DESCRIPTION
## Summary
- instantiate a NextResponse in the session endpoint to capture refreshed Supabase cookies
- forward the captured cookies via setAll so refreshed tokens are returned to the browser
- return the JSON payload with the response headers to propagate Set-Cookie updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a7dbac90832e8a8ea2a528e35acc