### PR TITLE
Sync premium status with server updates

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -109,6 +109,33 @@ export function UserProvider({
   }, [initialSession, initialSession?.access_token, initialSession?.refresh_token]);
 
   useEffect(() => {
+    if (!user) return;
+    if (typeof initialIsPremiumUser === "undefined") return;
+
+    const activeUserId = user.id;
+    if (
+      initialUserIdRef.current &&
+      initialUserIdRef.current !== activeUserId
+    ) {
+      return;
+    }
+
+    const metadataPremium =
+      user.app_metadata?.plan === "premium" ||
+      user.user_metadata?.is_premium === true;
+    const serverPremium = initialIsPremiumUser === true;
+
+    const nextPremium =
+      metadataPremium === serverPremium ? metadataPremium : serverPremium;
+
+    if (initialPremiumRef.current !== nextPremium) {
+      initialPremiumRef.current = nextPremium;
+    }
+
+    setIsPremiumUser((prev) => (prev === nextPremium ? prev : nextPremium));
+  }, [initialIsPremiumUser, user]);
+
+  useEffect(() => {
     let active = true;
 
     const { data: listener } = supabase.auth.onAuthStateChange(


### PR DESCRIPTION
## Summary
- update the user context to react to server-provided premium status changes and keep the premium flag in sync for the active user

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a75c065c832e85ee6d7cf0718f50