### PR TITLE
Handle Supabase logout indicator client-side

### DIFF
--- a/src/app/deconnexion/route.ts
+++ b/src/app/deconnexion/route.ts
@@ -14,7 +14,14 @@ export async function GET(req: Request) {
   const res = NextResponse.redirect(new URL("/connexion", req.url), 302);
   res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
   res.headers.set("Pragma", "no-cache");
-  res.headers.set("Clear-Site-Data", `"storage"`);
+  res.cookies.set({
+    name: "glift-logout",
+    value: "1",
+    path: "/",
+    maxAge: 60,
+    httpOnly: false,
+    sameSite: "lax",
+  });
 
   const supabase = createServerClient(url, anon, {
     cookies: {

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import type { ReactNode } from "react";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -8,6 +9,10 @@ import { UserProvider, useUser } from "@/context/UserContext";
 import SupabaseProvider from "./SupabaseProvider";
 import { AvatarProvider } from "@/context/AvatarContext";
 import type { Session } from "@supabase/supabase-js";
+import {
+  clearSupabaseStorage,
+  resetSupabaseClient,
+} from "@/lib/supabase/client";
 
 function LayoutContent({ children }: { children: ReactNode }) {
   const { isAuthenticated } = useUser();
@@ -32,6 +37,8 @@ export default function ClientLayout({
   initialSession,
   initialIsPremiumUser,
 }: ClientLayoutProps) {
+  useSupabaseLogoutSync();
+
   return (
     <SupabaseProvider>
       <UserProvider
@@ -44,4 +51,80 @@ export default function ClientLayout({
       </UserProvider>
     </SupabaseProvider>
   );
+}
+
+function useSupabaseLogoutSync() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const INDICATOR_COOKIE = "glift-logout";
+    const STORAGE_KEY = "glift:logout-signal";
+    const CHANNEL_NAME = "glift:auth";
+
+    let broadcastChannel: BroadcastChannel | null = null;
+
+    const clearIndicator = () => {
+      document.cookie = `${INDICATOR_COOKIE}=; path=/; max-age=0`;
+    };
+
+    const performLogoutCleanup = (shouldBroadcast: boolean) => {
+      clearSupabaseStorage();
+      resetSupabaseClient();
+
+      if (shouldBroadcast) {
+        try {
+          localStorage.setItem(STORAGE_KEY, `${Date.now()}`);
+        } catch (error) {
+          console.warn("Unable to write logout signal to localStorage", error);
+        }
+
+        try {
+          broadcastChannel?.postMessage({ type: "logout" });
+        } catch (error) {
+          console.warn("Unable to broadcast logout signal", error);
+        }
+      }
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && event.newValue) {
+        performLogoutCleanup(false);
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    const handleBroadcast = (event: MessageEvent) => {
+      if ((event.data as { type?: string } | undefined)?.type === "logout") {
+        performLogoutCleanup(false);
+      }
+    };
+
+    try {
+      broadcastChannel = new BroadcastChannel(CHANNEL_NAME);
+      broadcastChannel.addEventListener("message", handleBroadcast);
+    } catch (error) {
+      console.warn("BroadcastChannel is not available", error);
+      broadcastChannel = null;
+    }
+
+    const hasIndicator = () =>
+      document.cookie
+        .split(";")
+        .map((entry) => entry.trim())
+        .some((entry) => entry.startsWith(`${INDICATOR_COOKIE}=`));
+
+    if (hasIndicator()) {
+      clearIndicator();
+      performLogoutCleanup(true);
+    }
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      if (broadcastChannel) {
+        broadcastChannel.removeEventListener("message", handleBroadcast);
+        broadcastChannel.close();
+      }
+    };
+  }, []);
 }


### PR DESCRIPTION
## Summary
- replace the Clear-Site-Data header with a short-lived logout indicator cookie in the deconnexion route
- watch for the logout indicator on the client, clear Supabase storage, and broadcast the logout across tabs
- reuse local storage and broadcast channel listeners so other tabs clean up their Supabase sessions without losing app preferences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d790dd53fc832eb56ee1eac9fc4b81