### PR TITLE
Set session tab cookie in middleware for authenticated users

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,15 @@ export async function middleware(req: NextRequest) {
 
   const remember = req.cookies.get("sb-remember")?.value === "1";
   const sessionTab = req.cookies.get("sb-session-tab")?.value === "1";
+  if (user && !remember && !sessionTab) {
+    res.cookies.set({
+      name: "sb-session-tab",
+      value: "1",
+      path: "/",
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+  }
   const hasClientConsent = remember || sessionTab;
 
   const isCompte = pathname.startsWith("/compte");


### PR DESCRIPTION
## Summary
- set the `sb-session-tab` cookie in the middleware when a valid Supabase session exists without remembered consent
- mirror the client cookie attributes so subsequent requests pass the client consent check

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e41e05a0832e8fb0d08a63408efb