### PR TITLE
Refresh user session when tab regains focus

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { useSupabase } from "@/components/SupabaseProvider";
 
@@ -27,35 +27,67 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const [isAuthResolved, setIsAuthResolved] = useState(false);
   const [isPremiumUser, setIsPremiumUser] = useState(false);
 
+  const applySession = useCallback((nextSession: Session | null) => {
+    setSession(nextSession);
+    const nextUser = nextSession?.user ?? null;
+    setUser(nextUser);
+
+    const premium =
+      nextUser?.app_metadata?.plan === "premium" ||
+      nextUser?.user_metadata?.is_premium === true;
+    setIsPremiumUser(premium);
+  }, []);
+
   useEffect(() => {
+    let cancelled = false;
+
     supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session);
-      setUser(data.session?.user ?? null);
-
-      const premium =
-        data.session?.user?.app_metadata?.plan === "premium" ||
-        data.session?.user?.user_metadata?.is_premium === true;
-      setIsPremiumUser(premium);
-
+      if (cancelled) return;
+      applySession(data.session ?? null);
       setIsAuthResolved(true);
     });
 
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-      setUser(session?.user ?? null);
-
-      const premium =
-        session?.user?.app_metadata?.plan === "premium" ||
-        session?.user?.user_metadata?.is_premium === true;
-      setIsPremiumUser(premium);
-
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (cancelled) return;
+      applySession(nextSession ?? null);
       setIsAuthResolved(true);
     });
 
     return () => {
+      cancelled = true;
       listener.subscription.unsubscribe();
     };
-  }, [supabase]);
+  }, [supabase, applySession]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refreshSession = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (cancelled) return;
+      applySession(data.session ?? null);
+      setIsAuthResolved(true);
+    };
+
+    const handleFocus = () => {
+      void refreshSession();
+    };
+
+    const handleVisibility = () => {
+      if (!document.hidden) {
+        void refreshSession();
+      }
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [supabase, applySession]);
 
   return (
     <UserContext.Provider


### PR DESCRIPTION
## Summary
- deduplicate the session handling logic in the user context so the same path is used for initial load and auth change events
- refresh the Supabase session whenever the window regains focus or becomes visible to keep authentication state intact after tab switches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d80f0203b0832eb9dd3eca94bd6538