### PR TITLE
feat: add reusable Supabase SSR client helpers

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerClient } from "@supabase/ssr";
-import AdminHeader from "@/components/AdminHeader";
 import { Quicksand } from "next/font/google";
+import AdminHeader from "@/components/AdminHeader";
+import { createSSRClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
@@ -24,21 +23,10 @@ export const metadata: Metadata = {
 };
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
-
-  const { data: { user } } = await supabase.auth.getUser();
+  const supabase = await createSSRClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (!user) {
     redirect("/connexion");

--- a/src/app/api/account/change-password/route.ts
+++ b/src/app/api/account/change-password/route.ts
@@ -1,113 +1,113 @@
-import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export async function POST(req: Request) {
   try {
-    const { currentPassword, newPassword } = await req.json().catch(() => ({} as any))
+    const { currentPassword, newPassword } = await req.json().catch(() => ({} as any));
     if (!currentPassword || !newPassword) {
-      return NextResponse.json({ error: 'bad-request' }, { status: 400 })
+      return NextResponse.json({ error: "bad-request" }, { status: 400 });
     }
     if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-      return NextResponse.json({ error: 'server-misconfigured' }, { status: 500 })
+      return NextResponse.json({ error: "server-misconfigured" }, { status: 500 });
     }
     if (newPassword === currentPassword) {
-      return NextResponse.json({ error: 'same-password' }, { status: 400 })
+      return NextResponse.json({ error: "same-password" }, { status: 400 });
     }
 
-    const supabase = createRouteHandlerClient({ cookies })
+    const context = await createRouteHandlerClient();
+    const supabase = context.client;
 
-    // 1) Tenter via cookies (session côté serveur)
-    let authedBy: 'cookies' | 'bearer' | null = null
-    let jwtFromHeader: string | null = null
+    let authedBy: "cookies" | "bearer" | null = null;
+    let jwtFromHeader: string | null = null;
 
-    const { data: cookieUserData, error: cookieUserErr } = await supabase.auth.getUser()
-    let user = cookieUserData?.user ?? null
+    const { data: cookieUserData, error: cookieUserErr } = await supabase.auth.getUser();
+    let user = cookieUserData?.user ?? null;
 
-    // 2) Si pas d'utilisateur via cookies, essayer via Authorization: Bearer <token>
     if (!user) {
-      const authHeader = req.headers.get('authorization') || req.headers.get('Authorization')
-      if (authHeader?.startsWith('Bearer ')) {
-        jwtFromHeader = authHeader.slice(7)
-        const { data: bearerUserData } = await supabase.auth.getUser(jwtFromHeader)
-        user = bearerUserData?.user ?? null
-        if (user) authedBy = 'bearer'
+      const authHeader = req.headers.get("authorization") || req.headers.get("Authorization");
+      if (authHeader?.startsWith("Bearer ")) {
+        jwtFromHeader = authHeader.slice(7);
+        const { data: bearerUserData } = await supabase.auth.getUser(jwtFromHeader);
+        user = bearerUserData?.user ?? null;
+        if (user) authedBy = "bearer";
       }
     } else {
-      authedBy = 'cookies'
+      authedBy = "cookies";
     }
 
     if (!user) {
-      // ni cookies ni bearer → non authentifié
-      const detail = cookieUserErr?.message || 'no-session'
-      return NextResponse.json({ error: 'not-authenticated', details: detail }, { status: 401 })
+      const detail = cookieUserErr?.message || "no-session";
+      return context.applyCookies(
+        NextResponse.json({ error: "not-authenticated", details: detail }, { status: 401 })
+      );
     }
 
-    const email = user.email
+    const email = user.email;
     if (!email) {
-      return NextResponse.json({ error: 'no-email' }, { status: 400 })
+      return context.applyCookies(NextResponse.json({ error: "no-email" }, { status: 400 }));
     }
 
-    // 3) Vérifier l'ancien mot de passe via l’endpoint password grant (n’affecte pas la session)
     {
-      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/token?grant_type=password`
+      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/token?grant_type=password`;
       const verifyRes = await fetch(url, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-          'Content-Type': 'application/json',
+          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({ email, password: currentPassword }),
-      })
+      });
 
       if (!verifyRes.ok) {
         if (verifyRes.status === 400) {
-          // Invalid login credentials
-          return NextResponse.json({ error: 'invalid-current-password' }, { status: 400 })
+          return context.applyCookies(NextResponse.json({ error: "invalid-current-password" }, { status: 400 }));
         }
-        const body = await verifyRes.json().catch(() => ({}))
-        return NextResponse.json(
-          { error: 'verify-failed', details: body?.error_description || body?.msg || '' },
-          { status: 400 }
-        )
+        const body = await verifyRes.json().catch(() => ({}));
+        return context.applyCookies(
+          NextResponse.json(
+            { error: "verify-failed", details: body?.error_description || body?.msg || "" },
+            { status: 400 }
+          )
+        );
       }
     }
 
-    // 4) Mise à jour du mot de passe
-    if (authedBy === 'cookies') {
-      // On a une session côté serveur → updateUser direct
-      const { error: updateErr } = await supabase.auth.updateUser({ password: newPassword })
+    if (authedBy === "cookies") {
+      const { error: updateErr } = await supabase.auth.updateUser({ password: newPassword });
       if (updateErr) {
-        return NextResponse.json(
-          { error: 'update-failed', details: updateErr.message },
-          { status: 422 }
-        )
+        return context.applyCookies(
+          NextResponse.json(
+            { error: "update-failed", details: updateErr.message },
+            { status: 422 }
+          )
+        );
       }
-    } else if (authedBy === 'bearer' && jwtFromHeader) {
-      // Pas de cookies mais un Bearer → appeler GoTrue directement
-      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`
+    } else if (authedBy === "bearer" && jwtFromHeader) {
+      const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`;
       const putRes = await fetch(url, {
-        method: 'PUT',
+        method: "PUT",
         headers: {
-          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-          'Content-Type': 'application/json',
+          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+          "Content-Type": "application/json",
           Authorization: `Bearer ${jwtFromHeader}`,
         },
         body: JSON.stringify({ password: newPassword }),
-      })
+      });
       if (!putRes.ok) {
-        const body = await putRes.json().catch(() => ({}))
-        return NextResponse.json(
-          { error: 'update-failed', details: body?.msg || body?.error_description || '' },
-          { status: putRes.status || 422 }
-        )
+        const body = await putRes.json().catch(() => ({}));
+        return context.applyCookies(
+          NextResponse.json(
+            { error: "update-failed", details: body?.msg || body?.error_description || "" },
+            { status: putRes.status || 422 }
+          )
+        );
       }
     } else {
-      return NextResponse.json({ error: 'not-authenticated' }, { status: 401 })
+      return context.applyCookies(NextResponse.json({ error: "not-authenticated" }, { status: 401 }));
     }
 
-    return NextResponse.json({ ok: true }, { status: 200 })
+    return context.applyCookies(NextResponse.json({ ok: true }, { status: 200 }));
   } catch (e: any) {
-    return NextResponse.json({ error: 'server-error', details: e?.message || '' }, { status: 500 })
+    return NextResponse.json({ error: "server-error", details: e?.message || "" }, { status: 500 });
   }
 }

--- a/src/app/api/auth/remember/route.ts
+++ b/src/app/api/auth/remember/route.ts
@@ -1,25 +1,27 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export async function POST(req: Request) {
+  const clientContext = await createRouteHandlerClient();
+
   try {
     const { remember } = await req.json().catch(() => ({ remember: false as boolean }));
 
-    // ✅ cookies() peut être typé async selon ta version de Next → on attend sa résolution
-    const cookieStore = await cookies();
-    const access = cookieStore.get("sb-access-token");
-    const refresh = cookieStore.get("sb-refresh-token");
+    const access = clientContext.cookies.get("sb-access-token");
+    const refresh = clientContext.cookies.get("sb-refresh-token");
 
     if (!access || !refresh) {
-      return NextResponse.json(
-        { error: "No Supabase session cookies present." },
-        { status: 400 }
+      return clientContext.applyCookies(
+        NextResponse.json(
+          { error: "No Supabase session cookies present." },
+          { status: 400 }
+        )
       );
     }
 
     const resp = NextResponse.json({ success: true });
 
-    const maxAge = remember ? 60 * 60 * 24 * 180 : undefined; // 180 jours si "rester connecté"
+    const maxAge = remember ? 60 * 60 * 24 * 180 : undefined;
     const base = {
       httpOnly: true,
       sameSite: "lax" as const,
@@ -27,7 +29,6 @@ export async function POST(req: Request) {
       path: "/",
     };
 
-    // 🔁 Re-dépose les cookies Supabase avec (ou sans) expiration
     resp.cookies.set({
       name: "sb-access-token",
       value: access.value,
@@ -41,7 +42,6 @@ export async function POST(req: Request) {
       ...(maxAge ? { maxAge } : {}),
     });
 
-    // Indicateur lisible côté client pour configurer la persistance du SDK
     resp.cookies.set({
       name: "sb-remember",
       value: remember ? "1" : "0",
@@ -49,8 +49,8 @@ export async function POST(req: Request) {
       ...(maxAge ? { maxAge } : {}),
     });
 
-    return resp;
+    return clientContext.applyCookies(resp);
   } catch {
-    return NextResponse.json({ error: "Bad request" }, { status: 400 });
+    return clientContext.applyCookies(NextResponse.json({ error: "Bad request" }, { status: 400 }));
   }
 }

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import crypto from "crypto";
 
@@ -16,33 +15,15 @@ async function sendVerificationEmail(to: string, link: string) {
 }
 
 export async function POST(_req: NextRequest) {
-  const cookieStore = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: "", ...options, maxAge: 0 });
-        },
-      },
-    }
-  );
+  const { client, applyCookies } = await createRouteHandlerClient();
 
   const {
     data: { user },
     error: userErr,
-  } = await supabase.auth.getUser();
+  } = await client.auth.getUser();
 
   if (userErr || !user) {
-    return NextResponse.json({ error: "Non authentifié." }, { status: 401 });
+    return applyCookies(NextResponse.json({ error: "Non authentifié." }, { status: 401 }));
   }
 
   const admin = createAdminClient(
@@ -62,7 +43,7 @@ export async function POST(_req: NextRequest) {
   });
 
   if (insErr) {
-    return NextResponse.json({ error: "Impossible de générer le token." }, { status: 500 });
+    return applyCookies(NextResponse.json({ error: "Impossible de générer le token." }, { status: 500 }));
   }
 
   const base = siteUrl().replace(/\/+$/, "");
@@ -70,5 +51,5 @@ export async function POST(_req: NextRequest) {
 
   await sendVerificationEmail(user.email!, link);
 
-  return NextResponse.json({ ok: true });
+  return applyCookies(NextResponse.json({ ok: true }));
 }

--- a/src/app/api/auth/set-session/route.ts
+++ b/src/app/api/auth/set-session/route.ts
@@ -1,18 +1,19 @@
-import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
-  const { access_token, refresh_token } = await req.json().catch(() => ({}))
+  const { access_token, refresh_token } = await req.json().catch(() => ({}));
   if (!access_token || !refresh_token) {
-    return NextResponse.json({ error: 'bad-request' }, { status: 400 })
+    return NextResponse.json({ error: "bad-request" }, { status: 400 });
   }
 
-  const supabase = createRouteHandlerClient({ cookies })
-  const { error } = await supabase.auth.setSession({ access_token, refresh_token })
-  if (error) return NextResponse.json({ error: error.message }, { status: 401 })
+  const { client, applyCookies } = await createRouteHandlerClient();
+  const { error } = await client.auth.setSession({ access_token, refresh_token });
+  if (error) {
+    return applyCookies(NextResponse.json({ error: error.message }, { status: 401 }));
+  }
 
-  return NextResponse.json({ ok: true })
+  return applyCookies(NextResponse.json({ ok: true }));
 }

--- a/src/app/api/debug/session/route.ts
+++ b/src/app/api/debug/session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,11 +9,13 @@ export async function GET(req: NextRequest) {
   const guard = await requireAdmin(req);
   if (guard instanceof NextResponse) return guard;
 
-  const jar = await cookies();
-  const cookieKeys = jar.getAll().map((c) => c.name);
+  const { cookies } = await createRouteHandlerClient();
+  const cookieKeys = cookies.getAll().map((c) => c.name);
 
-  const { supabase } = guard;
-  const { data: { user }, error } = await supabase.auth.getUser();
+  const {
+    data: { user },
+    error,
+  } = await guard.supabase.auth.getUser();
 
   return NextResponse.json({
     cookieNames: cookieKeys,

--- a/src/app/api/email/resend/route.ts
+++ b/src/app/api/email/resend/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { sendVerificationEmail } from "@/lib/email/verifyEmail";
@@ -9,36 +8,23 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST() {
-  const response = new NextResponse();
+  const context = await createRouteHandlerClient();
 
   try {
     const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
     const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
-    const storeMaybe: any = (cookies as any)();
-    const cookieStore = typeof storeMaybe?.then === "function" ? await storeMaybe : storeMaybe;
-
-    const supabase = createServerClient(URL, ANON, {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string) {
-          cookieStore.delete(name);
-        },
-      },
-    });
-
-    const { data: { user }, error } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error,
+    } = await context.client.auth.getUser();
     if (error || !user?.email) {
-      return NextResponse.json({ ok: false, error: "not_authenticated" }, { status: 401, headers: response.headers });
+      return context.applyCookies(NextResponse.json({ ok: false, error: "not_authenticated" }, { status: 401 }));
     }
 
-    const admin = createAdminClient(URL, SERVICE, { auth: { persistSession: false, autoRefreshToken: false } });
+    const admin = createAdminClient(URL, SERVICE, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
 
     const token = randomUUID().replace(/-/g, "");
     const grace = new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();
@@ -47,15 +33,17 @@ export async function POST() {
       .from("email_verification_tokens")
       .upsert({ user_id: user.id, token, expires_at: grace }, { onConflict: "user_id" });
     if (upErr) {
-      return NextResponse.json({ ok: false, error: upErr.message }, { status: 500, headers: response.headers });
+      return context.applyCookies(NextResponse.json({ ok: false, error: upErr.message }, { status: 500 }));
     }
 
     await admin.from("profiles").update({ grace_expires_at: grace }).eq("id", user.id);
 
     await sendVerificationEmail({ email: user.email, token });
 
-    return NextResponse.json({ ok: true, sent: true }, { headers: response.headers });
+    return context.applyCookies(NextResponse.json({ ok: true, sent: true }));
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+    return context.applyCookies(
+      NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 })
+    );
   }
 }

--- a/src/app/deconnexion/route.ts
+++ b/src/app/deconnexion/route.ts
@@ -1,39 +1,30 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export async function GET(req: Request) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  const jar = await cookies();
+  const response = NextResponse.redirect(new URL("/connexion", req.url), 302);
+  response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Clear-Site-Data", `"storage"`);
 
-  const res = NextResponse.redirect(new URL("/connexion", req.url), 302);
-  res.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
-  res.headers.set("Pragma", "no-cache");
-  res.headers.set("Clear-Site-Data", `"storage"`);
+  const { client, cookies, applyCookies } = await createRouteHandlerClient(response);
 
-  const supabase = createServerClient(url, anon, {
-    cookies: {
-      get(n: string) { return jar.get(n)?.value; },
-      set(n: string, v: string, o: CookieOptions) { res.cookies.set({ name: n, value: v, ...o, path: "/" }); },
-      remove(n: string, o: CookieOptions) { res.cookies.set({ name: n, value: "", ...o, path: "/", maxAge: 0 }); },
-    },
-  });
+  try {
+    await client.auth.signOut({ scope: "global" });
+  } catch {}
 
-  try { await supabase.auth.signOut({ scope: "global" }); } catch {}
+  response.cookies.set({ name: "sb-remember", value: "", path: "/", maxAge: 0 });
+  response.cookies.set({ name: "sb-session-tab", value: "", path: "/", maxAge: 0 });
 
-  res.cookies.set({ name: "sb-remember", value: "", path: "/", maxAge: 0 });
-  res.cookies.set({ name: "sb-session-tab", value: "", path: "/", maxAge: 0 });
-
-  for (const c of jar.getAll()) {
-    if (c.name.startsWith("sb-")) {
-      res.cookies.set({ name: c.name, value: "", path: "/", maxAge: 0 });
+  for (const cookie of cookies.getAll()) {
+    if (cookie.name.startsWith("sb-")) {
+      response.cookies.set({ name: cookie.name, value: "", path: "/", maxAge: 0 });
     }
   }
 
-  return res;
+  return applyCookies(response);
 }

--- a/src/app/entrainements/layout.tsx
+++ b/src/app/entrainements/layout.tsx
@@ -1,7 +1,5 @@
-// src/app/compte/layout.tsx
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerClient } from "@supabase/ssr";
+import { createSSRClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
@@ -10,20 +8,7 @@ export default async function CompteLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
-
+  const supabase = await createSSRClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,7 @@ import { Quicksand } from "next/font/google";
 import ClientLayout from "@/components/ClientLayout";
 import { UnlockScroll } from "@/components/UnlockScroll";
 import VerifyEmailTopBar from "@/components/auth/VerifyEmailTopBar";
-
-import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { createSSRClient } from "@/lib/supabase/server";
 
 const quicksand = Quicksand({
   subsets: ["latin"],
@@ -29,32 +27,18 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-if (process.env.NEXT_PUBLIC_DEBUG === '1') {
-  console.log('[RootLayout] render');
-}
+  if (process.env.NEXT_PUBLIC_DEBUG === "1") {
+    console.log("[RootLayout] render");
+  }
 
-  // Supabase SSR
-  const cookieStoreMaybe: any = (cookies as any)();
-  const cookieStore =
-    typeof cookieStoreMaybe?.then === "function" ? await cookieStoreMaybe : cookieStoreMaybe;
+  const supabase = await createSSRClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => cookieStore.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
-
-  const { data: { user } } = await supabase.auth.getUser();
   let plan: string | null = null;
 
   if (user) {
-    // 🔧 IMPORTANT: pas de .single()/.maybeSingle() → on fait LIMIT 1
     const { data: subRows } = await supabase
       .from("user_subscriptions")
       .select("plan")
@@ -70,7 +54,6 @@ if (process.env.NEXT_PUBLIC_DEBUG === '1') {
       <body className={quicksand.className}>
         <UnlockScroll />
         <VerifyEmailTopBar />
-        {/* on ne passe pas encore `plan` si tes composants ne l’acceptent pas */}
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,11 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { createServerClient } from "@supabase/ssr";
 import HeroConcept from "@/components/HeroConcept";
+import { createSSRClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
-
+  const supabase = await createSSRClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/src/lib/auth/requireAdmin.ts
+++ b/src/lib/auth/requireAdmin.ts
@@ -1,28 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { createSSRClient } from "@/lib/supabase/server";
 
 export type AdminGuardOk = {
   user: any;
-  supabase: ReturnType<typeof createServerClient>;
+  supabase: Awaited<ReturnType<typeof createSSRClient>>;
 };
 
-export async function requireAdmin(req: NextRequest): Promise<AdminGuardOk | NextResponse> {
-  const jar = await cookies();
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get: (name: string) => jar.get(name)?.value,
-        set: () => {},
-        remove: () => {},
-      },
-    }
-  );
-
-  const { data: { user } } = await supabase.auth.getUser();
+export async function requireAdmin(_req: NextRequest): Promise<AdminGuardOk | NextResponse> {
+  const supabase = await createSSRClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   const isAdmin =
     (user as any)?.app_metadata?.is_admin === true ||
     (user as any)?.user_metadata?.is_admin === true;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,20 +1,124 @@
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies as nextCookies } from "next/headers";
+import type { NextResponse } from "next/server";
 
-export function createClient() {
-  const cookieStore = cookies() as unknown as ReadonlyMap<string, { value: string }>;
+type NextCookies = Awaited<ReturnType<typeof nextCookies>>;
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set() {},
-        remove() {},
-      },
+type Awaitable<T> = T | Promise<T>;
+
+type RouteHandlerClient = {
+  client: ReturnType<typeof createServerClient>;
+  applyCookies: (response: NextResponse) => NextResponse;
+};
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+function isPromiseLike<T>(value: Awaitable<T>): value is Promise<T> {
+  return typeof (value as Promise<T>)?.then === "function";
+}
+
+async function resolveCookies(): Promise<NextCookies> {
+  const storeMaybe = nextCookies() as Awaitable<NextCookies>;
+  return isPromiseLike(storeMaybe) ? await storeMaybe : storeMaybe;
+}
+
+type CookieMutation =
+  | { type: "set"; name: string; value: string; options?: CookieOptions }
+  | { type: "remove"; name: string; options?: CookieOptions };
+
+type CookieCache = Map<string, { value: string | null; options?: CookieOptions }>;
+
+function withDefaultPath(options?: CookieOptions): CookieOptions {
+  return { path: "/", ...options };
+}
+
+function propagateToResponse(response: NextResponse, mutation: CookieMutation) {
+  if (mutation.type === "set") {
+    const options = withDefaultPath(mutation.options);
+    response.cookies.set({
+      name: mutation.name,
+      value: mutation.value,
+      ...options,
+    });
+    return;
+  }
+
+  const options = withDefaultPath(mutation.options);
+  response.cookies.set({
+    name: mutation.name,
+    value: "",
+    maxAge: 0,
+    ...options,
+  });
+}
+
+function createSupabaseClient(cookieStore: NextCookies, response?: NextResponse) {
+  const cache: CookieCache = new Map();
+  const mutations: CookieMutation[] = [];
+
+  const getFromCache = (name: string) => {
+    if (cache.has(name)) {
+      const cached = cache.get(name)!;
+      return cached.value ?? undefined;
     }
-  );
+
+    return cookieStore.get(name)?.value;
+  };
+
+  const client = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      get(name: string) {
+        return getFromCache(name);
+      },
+      set(name: string, value: string, options?: CookieOptions) {
+        const normalized = withDefaultPath(options);
+        cache.set(name, { value, options: normalized });
+        mutations.push({ type: "set", name, value, options: normalized });
+        if (response) {
+          propagateToResponse(response, { type: "set", name, value, options: normalized });
+        }
+      },
+      remove(name: string, options?: CookieOptions) {
+        const normalized = withDefaultPath(options);
+        cache.set(name, { value: null, options: normalized });
+        mutations.push({ type: "remove", name, options: normalized });
+        if (response) {
+          propagateToResponse(response, { type: "remove", name, options: normalized });
+        }
+      },
+    },
+  });
+
+  const applyCookies = (target: NextResponse) => {
+    for (const mutation of mutations) {
+      propagateToResponse(target, mutation);
+    }
+    return target;
+  };
+
+  return { client, applyCookies } satisfies RouteHandlerClient;
+}
+
+export async function createSSRClient(response?: NextResponse) {
+  const cookieStore = await resolveCookies();
+  return createSupabaseClient(cookieStore, response).client;
+}
+
+export async function createRouteHandlerClient(response?: NextResponse) {
+  const cookieStore = await resolveCookies();
+  const { client, applyCookies } = createSupabaseClient(cookieStore, response);
+
+  return {
+    client,
+    applyCookies,
+    cookies: cookieStore,
+    withResponse(target: NextResponse) {
+      return applyCookies(target);
+    },
+  };
+}
+
+export async function createClient() {
+  return createSSRClient();
 }


### PR DESCRIPTION
## Summary
- add shared Supabase SSR utilities that normalize cookie access and propagate updates to NextResponse
- switch server components and layouts to the new helpers for consistent session handling
- refactor API and route handlers to rely on createRouteHandlerClient when reading or mutating Supabase cookies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d83e94c6bc832eb393b1b9b2cba459