### PR TITLE
refactor: centralize supabase service role client

### DIFF
--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
 import crypto from "crypto";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -45,10 +45,7 @@ export async function POST(_req: NextRequest) {
     return NextResponse.json({ error: "Non authentifié." }, { status: 401 });
   }
 
-  const admin = createAdminClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  const admin = getServiceRoleClient();
 
   const token = crypto.randomBytes(32).toString("hex");
   const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 48);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { sendVerificationEmail } from "@/lib/email/verifyEmail";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,13 +13,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: "Email et mot de passe requis." }, { status: 400 });
     }
 
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const service = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
     if (!url || !service) {
       return NextResponse.json({ success: false, error: "Supabase env manquantes." }, { status: 500 });
     }
 
-    const admin = createAdminClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
+    const admin = getServiceRoleClient();
 
     const { data: created, error: createErr } = await admin.auth.admin.createUser({
       email,

--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -61,9 +61,7 @@ export async function POST() {
     return NextResponse.json({ error: "not-authenticated" }, { status: 401 });
   }
 
-  const admin = createAdminClient(url, service, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
+  const admin = getServiceRoleClient();
 
   const safeDelete = async (table: string, col: string, val: string) => {
     const { error } = await admin.from(table).delete().eq(col, val);

--- a/src/app/api/email/confirm/route.ts
+++ b/src/app/api/email/confirm/route.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 function siteUrl() {
   return (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
@@ -21,14 +21,10 @@ function renderHtml(link: string) {
 
 /** Envoie l’email de vérification avec login automatique via Magic Link */
 export async function sendVerificationEmail({ email, token }: { email: string; token: string }) {
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
   const RESEND_KEY = process.env.RESEND_API_KEY;
   const RESEND_FROM = process.env.RESEND_FROM || "Glift <no-reply@glift.io>";
 
-  const admin = createAdminClient(URL, SERVICE, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  const admin = getServiceRoleClient();
 
   // Après login, on veut marquer vérifié puis envoyer vers /compte#mes-informations
   const confirmApi = `/api/email/confirm?token=${encodeURIComponent(token)}&dest=${encodeURIComponent("/compte#mes-informations")}`;

--- a/src/app/api/email/resend/route.ts
+++ b/src/app/api/email/resend/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { sendVerificationEmail } from "@/lib/email/verifyEmail";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,7 +14,6 @@ export async function POST() {
   try {
     const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-    const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
     const storeMaybe: any = (cookies as any)();
     const cookieStore = typeof storeMaybe?.then === "function" ? await storeMaybe : storeMaybe;
@@ -38,7 +37,7 @@ export async function POST() {
       return NextResponse.json({ ok: false, error: "not_authenticated" }, { status: 401, headers: response.headers });
     }
 
-    const admin = createAdminClient(URL, SERVICE, { auth: { persistSession: false, autoRefreshToken: false } });
+    const admin = getServiceRoleClient();
 
     const token = randomUUID().replace(/-/g, "");
     const grace = new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();

--- a/src/app/api/verify-email/route.ts
+++ b/src/app/api/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,10 +12,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Token manquant." }, { status: 400 });
   }
 
-  const admin = createAdminClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  const admin = getServiceRoleClient();
 
   const { data: row, error } = await admin
     .from("email_verification_tokens")

--- a/src/lib/email/verifyEmail.ts
+++ b/src/lib/email/verifyEmail.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 function siteUrl() {
   return (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
@@ -20,14 +20,10 @@ function renderHtml(link: string) {
 }
 
 export async function sendVerificationEmail({ email, token }: { email: string; token: string }) {
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
   const RESEND_KEY = process.env.RESEND_API_KEY;
   const RESEND_FROM = process.env.RESEND_FROM || "Glift <no-reply@glift.io>";
 
-  const admin = createAdminClient(URL, SERVICE, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  const admin = getServiceRoleClient();
 
   const confirmApi = `/api/email/confirm?token=${encodeURIComponent(token)}&dest=${encodeURIComponent("/compte#mes-informations")}`;
   const redirectTo = `${siteUrl()}/auth/callback?next=${encodeURIComponent(confirmApi)}`;

--- a/src/lib/supabase/serviceRole.ts
+++ b/src/lib/supabase/serviceRole.ts
@@ -1,0 +1,23 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/supabase";
+
+const globalForSupabase = globalThis as unknown as {
+  __supabaseServiceRoleClient?: SupabaseClient<Database>;
+};
+
+export function getServiceRoleClient() {
+  if (!globalForSupabase.__supabaseServiceRoleClient) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!url || !serviceRoleKey) {
+      throw new Error("Supabase service role environment variables are not configured.");
+    }
+
+    globalForSupabase.__supabaseServiceRoleClient = createClient<Database>(url, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  return globalForSupabase.__supabaseServiceRoleClient;
+}


### PR DESCRIPTION
## Summary
- add a memoized Supabase service role client helper under src/lib/supabase
- refactor API routes and email utilities to reuse the shared service role client helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d83e9f45e4832ebf305f6a91382cd9