### PR TITLE
Centralize Supabase service role client

### DIFF
--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
 import crypto from "crypto";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -26,10 +26,12 @@ export async function POST(_req: NextRequest) {
     return applyCookies(NextResponse.json({ error: "Non authentifié." }, { status: 401 }));
   }
 
-  const admin = createAdminClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  let admin;
+  try {
+    admin = getServiceRoleClient();
+  } catch (_error) {
+    return applyCookies(NextResponse.json({ error: "Supabase env manquantes." }, { status: 500 }));
+  }
 
   const token = crypto.randomBytes(32).toString("hex");
   const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 48);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { sendVerificationEmail } from "@/lib/email/verifyEmail";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,13 +13,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: "Email et mot de passe requis." }, { status: 400 });
     }
 
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const service = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-    if (!url || !service) {
+    let admin;
+    try {
+      admin = getServiceRoleClient();
+    } catch (_error) {
       return NextResponse.json({ success: false, error: "Supabase env manquantes." }, { status: 500 });
     }
-
-    const admin = createAdminClient(url, service, { auth: { persistSession: false, autoRefreshToken: false } });
 
     const { data: created, error: createErr } = await admin.auth.admin.createUser({
       email,

--- a/src/app/api/email/confirm/route.ts
+++ b/src/app/api/email/confirm/route.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 function siteUrl() {
   return (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
@@ -21,14 +21,10 @@ function renderHtml(link: string) {
 
 /** Envoie l’email de vérification avec login automatique via Magic Link */
 export async function sendVerificationEmail({ email, token }: { email: string; token: string }) {
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
   const RESEND_KEY = process.env.RESEND_API_KEY;
   const RESEND_FROM = process.env.RESEND_FROM || "Glift <no-reply@glift.io>";
 
-  const admin = createAdminClient(URL, SERVICE, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  const admin = getServiceRoleClient();
 
   // Après login, on veut marquer vérifié puis envoyer vers /compte#mes-informations
   const confirmApi = `/api/email/confirm?token=${encodeURIComponent(token)}&dest=${encodeURIComponent("/compte#mes-informations")}`;

--- a/src/app/api/verify-email/route.ts
+++ b/src/app/api/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,10 +12,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Token manquant." }, { status: 400 });
   }
 
-  const admin = createAdminClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  let admin;
+  try {
+    admin = getServiceRoleClient();
+  } catch (_error) {
+    return NextResponse.json({ error: "Supabase env manquantes." }, { status: 500 });
+  }
 
   const { data: row, error } = await admin
     .from("email_verification_tokens")

--- a/src/lib/email/verifyEmail.ts
+++ b/src/lib/email/verifyEmail.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { getServiceRoleClient } from "@/lib/supabase/serviceRole";
 
 function siteUrl() {
   return (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
@@ -20,14 +20,10 @@ function renderHtml(link: string) {
 }
 
 export async function sendVerificationEmail({ email, token }: { email: string; token: string }) {
-  const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY!;
   const RESEND_KEY = process.env.RESEND_API_KEY;
   const RESEND_FROM = process.env.RESEND_FROM || "Glift <no-reply@glift.io>";
 
-  const admin = createAdminClient(URL, SERVICE, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  const admin = getServiceRoleClient();
 
   const confirmApi = `/api/email/confirm?token=${encodeURIComponent(token)}&dest=${encodeURIComponent("/compte#mes-informations")}`;
   const redirectTo = `${siteUrl()}/auth/callback?next=${encodeURIComponent(confirmApi)}`;

--- a/src/lib/supabase/serviceRole.ts
+++ b/src/lib/supabase/serviceRole.ts
@@ -1,0 +1,30 @@
+import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/types/supabase";
+
+let client: SupabaseClient<Database> | null = null;
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable ${name}`);
+  }
+  return value;
+}
+
+export function getServiceRoleClient() {
+  if (!client) {
+    const url = requireEnv("NEXT_PUBLIC_SUPABASE_URL");
+    const serviceKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+    client = createClient<Database>(url, serviceKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+
+  return client;
+}


### PR DESCRIPTION
## Summary
- add a memoized Supabase service-role client helper
- refactor server routes and mailer utilities to reuse the helper and standardize env error handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d83bcee318832e86319b83306753df