### PR TITLE
Handle missing session tokens during client rehydration

### DIFF
--- a/src/lib/ensureClientSession.ts
+++ b/src/lib/ensureClientSession.ts
@@ -10,17 +10,46 @@ export async function ensureClientSession(supabase: SupabaseClient) {
   // Mutualise les appels concurrents
   if (!inFlight) {
     inFlight = (async () => {
-      const res = await fetch("/api/auth/session", { credentials: "include" });
-      if (!res.ok) { inFlight = null; return null; }
-      const tokens = await res.json().catch(() => null);
-      if (!tokens) { inFlight = null; return null; }
+      try {
+        const res = await fetch("/api/auth/session", { credentials: "include" });
+        if (!res.ok) {
+          console.error("ensureClientSession: échec de la récupération de la session", res.status, res.statusText);
+          return null;
+        }
 
-      const { data } = await supabase.auth.setSession({
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-      });
-      inFlight = null;
-      return data.session ?? null;
+        const { session: refreshedSession } = (await res.json()) as {
+          session?: { access_token?: string; refresh_token?: string };
+        };
+
+        if (!refreshedSession) {
+          console.error("ensureClientSession: aucune session retournée par /api/auth/session");
+          return null;
+        }
+
+        const { access_token, refresh_token } = refreshedSession;
+
+        if (!access_token || !refresh_token) {
+          console.error("ensureClientSession: jetons manquants dans la session rafraîchie");
+          return null;
+        }
+
+        const { data, error } = await supabase.auth.setSession({
+          access_token,
+          refresh_token,
+        });
+
+        if (error) {
+          console.error("ensureClientSession: impossible de définir la session Supabase", error);
+          return null;
+        }
+
+        return data.session ?? null;
+      } catch (error) {
+        console.error("ensureClientSession: erreur inattendue lors de la réhydratation", error);
+        return null;
+      } finally {
+        inFlight = null;
+      }
     })();
   }
   return inFlight;


### PR DESCRIPTION
## Summary
- parse `/api/auth/session` responses as `{ session }` and guard against missing tokens
- add explicit logging and error handling when rehydrating the Supabase client session

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d84c904ecc832e9986336e8a538855