### PR TITLE
feat: centralize subscription state in user context

### DIFF
--- a/src/components/AuthDebug.tsx
+++ b/src/components/AuthDebug.tsx
@@ -3,8 +3,8 @@
 import { useUser } from "@/context/UserContext";
 
 export default function AuthDebug() {
-  const { user, isAuthenticated } = useUser();
-  const isPremiumUser = user?.user_metadata?.is_premium === true;
+  const { user, isAuthenticated, isPremiumUser, plan, isSubscriptionResolved } =
+    useUser();
 
   if (!user) return null;
 
@@ -19,7 +19,13 @@ export default function AuthDebug() {
           <strong>Authentifié :</strong> {isAuthenticated ? "Oui" : "Non"}
         </li>
         <li>
+          <strong>Plan :</strong> {plan ?? "—"}
+        </li>
+        <li>
           <strong>Premium :</strong> {isPremiumUser ? "Oui" : "Non"}
+        </li>
+        <li>
+          <strong>Plan chargé :</strong> {isSubscriptionResolved ? "Oui" : "Non"}
         </li>
       </ul>
     </div>

--- a/src/components/shop/ShopCard.tsx
+++ b/src/components/shop/ShopCard.tsx
@@ -36,8 +36,9 @@ export default function ShopCard({ offer }: Props) {
   const [showPremiumModal, setShowPremiumModal] = useState(false);
   const [lockedHover, setLockedHover] = useState(false);
   const [countdown, setCountdown] = useState("");
-  const { user, isPremiumUser } = useUser() || {};
+  const { user, isPremiumUser, isSubscriptionResolved } = useUser();
   const isAuthenticated = !!user;
+  const subscriptionPending = isAuthenticated && !isSubscriptionResolved;
 
   const supabase = createClient();
 
@@ -301,6 +302,21 @@ export default function ShopCard({ offer }: Props) {
                 height={15}
               />
               Profiter de cette offre
+            </button>
+          ) : subscriptionPending ? (
+            <button
+              onMouseEnter={() => setLockedHover(true)}
+              onMouseLeave={() => setLockedHover(false)}
+              className="w-auto mt-[20px] mb-[30px] px-6 h-[44px] bg-[#F2F1F6] text-[#D7D4DC] rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto cursor-wait"
+              disabled
+            >
+              <Image
+                src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
+                alt=""
+                width={15}
+                height={15}
+              />
+              Chargement...
             </button>
           ) : !isPremiumUser ? (
             <button

--- a/src/hooks/useUserSubscription.ts
+++ b/src/hooks/useUserSubscription.ts
@@ -1,72 +1,14 @@
-import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabase/client";
+import { useUser } from "@/context/UserContext";
 
 type Plan = "premium" | "starter" | "basic" | string | null;
 
 export default function useUserSubscription() {
-  const [plan, setPlan] = useState<Plan>(null);
-  const [isPremiumUser, setIsPremiumUser] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [userId, setUserId] = useState<string | null>(null);
+  const { user, plan, isPremiumUser, isSubscriptionResolved } = useUser();
 
-  useEffect(() => {
-    let alive = true;
-    const supabase = createClient();
-
-    const fetchStatus = async () => {
-      setLoading(true);
-
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      if (!alive) return;
-
-      if (!user) {
-        setUserId(null);
-        setPlan(null);
-        setIsPremiumUser(false);
-        setLoading(false);
-        return;
-      }
-
-      setUserId(user.id);
-
-      // 🔧 IMPORTANT : pas de .single() / .maybeSingle() → LIMIT 1 pour éviter le 406 quand 0 ligne
-      const { data: rows, error } = await supabase
-        .from("user_subscriptions")
-        .select("plan")
-        .eq("user_id", user.id)
-        .limit(1);
-
-      if (!alive) return;
-
-      if (error) {
-        // RLS/REST error → on ne bloque pas l'UI, on retombe en non-premium
-        setPlan(null);
-        setIsPremiumUser(false);
-        setLoading(false);
-        return;
-      }
-
-      const p = (rows?.[0]?.plan ?? null) as Plan;
-      setPlan(p);
-      setIsPremiumUser(String(p).toLowerCase() === "premium");
-      setLoading(false);
-    };
-
-    fetchStatus();
-
-    // Refetch sur login/logout
-    const { data: sub } = supabase.auth.onAuthStateChange(() => {
-      fetchStatus();
-    });
-
-    return () => {
-      alive = false;
-      sub?.subscription?.unsubscribe();
-    };
-  }, []);
-
-  return { isPremiumUser, loading, userId, plan };
+  return {
+    plan: (plan ?? null) as Plan,
+    isPremiumUser,
+    userId: user?.id ?? null,
+    loading: !isSubscriptionResolved,
+  };
 }


### PR DESCRIPTION
## Summary
- extend the user context to fetch the subscription plan, expose premium status, and track resolution state
- refactor the subscription hook and consumer UI so they rely on the shared context and avoid flashing locked states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d84cfd9058832ea322594b76a6be05