### PR TITLE
Harden Supabase configuration validation and session refresh

### DIFF
--- a/src/app/api/auth/user/route.ts
+++ b/src/app/api/auth/user/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  let plan: string | null = null;
+
+  if (user) {
+    const { data: subRows, error: subscriptionError } = await supabase
+      .from("user_subscriptions")
+      .select("plan")
+      .eq("user_id", user.id)
+      .limit(1);
+
+    if (subscriptionError) {
+      return NextResponse.json({ error: subscriptionError.message }, { status: 500 });
+    }
+
+    plan = subRows?.[0]?.plan ?? null;
+  }
+
+  return NextResponse.json({ user, plan });
+}

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,22 +1,21 @@
-'use client';
+"use client";
 
-import { usePathname } from 'next/navigation';
-import { ReactNode, useEffect } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import { Session } from '@supabase/supabase-js';
-import Header from './Header';
-import Footer from './Footer';
-import FooterPublic from './FooterPublic';
-import { UserProvider } from "@/context/UserContext"
-import SupabaseProvider from './SupabaseProvider';
-import { AvatarProvider } from '@/context/AvatarContext';
-import { useUser } from "@/context/UserContext";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import Header from "./Header";
+import Footer from "./Footer";
+import FooterPublic from "./FooterPublic";
+import { UserProvider, useUser } from "@/context/UserContext";
+import SupabaseProvider from "./SupabaseProvider";
+import { AvatarProvider } from "@/context/AvatarContext";
 
 function LayoutContent({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { isAuthenticated } = useUser();
 
-  console.log('✅ ClientLayout rendu pour', pathname);
+  if (process.env.NEXT_PUBLIC_DEBUG === "1") {
+    console.log("✅ ClientLayout rendu pour", pathname);
+  }
 
   return (
     <>

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,15 +1,13 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/supabase";
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./config";
 
 let browserClient: SupabaseClient<Database> | null = null;
 
 export function createClient() {
   if (!browserClient) {
-    browserClient = createBrowserClient<Database>(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    );
+    browserClient = createBrowserClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
   }
   return browserClient;
 }

--- a/src/lib/supabase/config.ts
+++ b/src/lib/supabase/config.ts
@@ -1,0 +1,16 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL environment variable. Please set it in your environment before starting the application."
+  );
+}
+
+if (!SUPABASE_ANON_KEY) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable. Please set it in your environment before starting the application."
+  );
+}
+
+export { SUPABASE_URL, SUPABASE_ANON_KEY };

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,20 +1,23 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./config";
+
+type CookieOptions = Parameters<ReturnType<typeof cookies>["set"]>[2];
 
 export function createClient() {
-  const cookieStore = cookies() as unknown as ReadonlyMap<string, { value: string }>;
+  const cookieStore = cookies();
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set() {},
-        remove() {},
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
       },
-    }
-  );
+      set(name: string, value: string, options?: CookieOptions) {
+        cookieStore.set(name, value, options);
+      },
+      remove(name: string, options?: CookieOptions) {
+        cookieStore.delete(name, options);
+      },
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- add runtime validation for Supabase environment variables and reuse shared configuration across clients
- enable Supabase SSR cookie updates via a server API route and consume it from the root layout
- guard production logging, respect the Supabase provider in the admin offer page, and expose consent fallbacks in middleware

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8d27f7b0c832eaa7e396dbde969a4