### PR TITLE
Ensure Supabase session hydrates client context on load

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,7 +50,11 @@ if (process.env.NEXT_PUBLIC_DEBUG === '1') {
     }
   );
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const user = session?.user ?? null;
   let plan: string | null = null;
 
   if (user) {
@@ -71,7 +75,7 @@ if (process.env.NEXT_PUBLIC_DEBUG === '1') {
         <UnlockScroll />
         <VerifyEmailTopBar />
         {/* on ne passe pas encore `plan` si tes composants ne l’acceptent pas */}
-        <ClientLayout>{children}</ClientLayout>
+        <ClientLayout initialSession={session}>{children}</ClientLayout>
       </body>
     </html>
   );

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { ReactNode, useEffect } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import { Session } from '@supabase/supabase-js';
+import { ReactNode } from 'react';
+import type { Session } from '@supabase/supabase-js';
 import Header from './Header';
 import Footer from './Footer';
 import FooterPublic from './FooterPublic';
@@ -12,7 +11,16 @@ import SupabaseProvider from './SupabaseProvider';
 import { AvatarProvider } from '@/context/AvatarContext';
 import { useUser } from "@/context/UserContext";
 
-function LayoutContent({ children }: { children: ReactNode }) {
+type LayoutContentProps = {
+  children: ReactNode;
+};
+
+type ClientLayoutProps = {
+  children: ReactNode;
+  initialSession?: Session | null;
+};
+
+function LayoutContent({ children }: LayoutContentProps) {
   const pathname = usePathname();
   const { isAuthenticated } = useUser();
 
@@ -27,10 +35,10 @@ function LayoutContent({ children }: { children: ReactNode }) {
   );
 }
 
-export default function ClientLayout({ children }: { children: ReactNode }) {
+export default function ClientLayout({ children, initialSession = null }: ClientLayoutProps) {
   return (
     <SupabaseProvider>
-      <UserProvider>
+      <UserProvider initialSession={initialSession}>
         <AvatarProvider>
           <LayoutContent>{children}</LayoutContent>
         </AvatarProvider>


### PR DESCRIPTION
## Summary
- pass the server resolved Supabase session through ClientLayout into the UserProvider
- hydrate the user context with any existing session before running client listeners
- keep the auth listener to update user data while marking auth as resolved once the session is read

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ddec56b0832e88f1543682563191