### PR TITLE
Fix lint warnings across admin and onboarding pages

### DIFF
--- a/src/app/admin/create-program/page.tsx
+++ b/src/app/admin/create-program/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 import ImageUploader from "@/app/admin/components/ImageUploader";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
@@ -54,6 +53,62 @@ export default function CreateProgramPage() {
     goal: "",
   });
 
+  const fetchProgram = useCallback(
+    async (id: string) => {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from("program_store")
+        .select("*")
+        .eq("id", id)
+        .single();
+
+      if (error) {
+        console.error("Erreur lors de la récupération :", error);
+        setLoading(false);
+      } else if (data) {
+        const {
+          title,
+          level,
+          gender,
+          duration,
+          sessions,
+          description,
+          link,
+          image,
+          image_alt,
+          partner_image,
+          partner_image_alt,
+          partner_link,
+          linked_program_id,
+          partner_name,
+          status,
+          goal,
+        } = data;
+
+        setProgram({
+          title,
+          level,
+          gender,
+          duration,
+          sessions,
+          description,
+          link,
+          image,
+          image_alt,
+          partner_image,
+          partner_image_alt,
+          partner_link,
+          linked_program_id,
+          partner_name,
+          status,
+          goal,
+        });
+        setLoading(false);
+      }
+    },
+    [supabase]
+  );
+
   useEffect(() => {
     const id = searchParams?.get("id");
     if (id) {
@@ -62,60 +117,7 @@ export default function CreateProgramPage() {
     } else {
       setLoading(false);
     }
-  }, [searchParams]);
-
-  const fetchProgram = async (id: string) => {
-    setLoading(true);
-    const { data, error } = await supabase
-      .from("program_store")
-      .select("*")
-      .eq("id", id)
-      .single();
-
-    if (error) {
-      console.error("Erreur lors de la récupération :", error);
-      setLoading(false);
-    } else if (data) {
-      const {
-        title,
-        level,
-        gender,
-        duration,
-        sessions,
-        description,
-        link,
-        image,
-        image_alt,
-        partner_image,
-        partner_image_alt,
-        partner_link,
-        linked_program_id,
-        partner_name,
-        status,
-        goal,
-      } = data;
-
-      setProgram({
-        title,
-        level,
-        gender,
-        duration,
-        sessions,
-        description,
-        link,
-        image,
-        image_alt,
-        partner_image,
-        partner_image_alt,
-        partner_link,
-        linked_program_id,
-        partner_name,
-        status,
-        goal,
-      });
-      setLoading(false);
-    }
-  };
+  }, [fetchProgram, searchParams]);
 
   const handleSave = async () => {
     if (programId) {
@@ -145,17 +147,6 @@ export default function CreateProgramPage() {
       }
     }
   };
-
-  const isFormValid =
-  program.title.trim() !== "" &&
-  program.level !== "" &&
-  program.gender !== "" &&
-  program.goal !== "" &&
-  program.duration.trim() !== "" &&
-  program.sessions > 0 &&
-  program.description.trim() !== "" &&
-  program.image !== "" &&
-  program.status !== "";
 
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">

--- a/src/app/admin/entrainements/[id]/page.tsx
+++ b/src/app/admin/entrainements/[id]/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams, useParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { useMemo } from "react";
 import { useUser } from "@/context/UserContext";
-import { Row } from "@/types/training";
 import EditableTitle from "@/components/EditableTitle";
 import TrainingTable from "@/components/TrainingTable";
 import TableActionsBar from "@/components/TableActionsBar";
@@ -21,6 +19,7 @@ import { useTrainingColumns } from "@/utils/useTrainingColumns";
 import { useSeriesChange } from "@/utils/useSeriesChange";
 import { useCheckboxChange } from "@/utils/useCheckboxChange";
 import { useIconHover } from "@/utils/useIconHover";
+import Image from "next/image";
 
 export default function AdminEntrainementDetailPage() {
   const params = useParams();
@@ -32,8 +31,8 @@ export default function AdminEntrainementDetailPage() {
 
   // ✅ States
   const [editing, setEditing] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
-  const [hoveredSuperset, setHoveredSuperset] = useState(false);
+  const [, setIsEditing] = useState(false);
+  const [, setHoveredSuperset] = useState(false);
 
   // ✅ Training data
   const { rows, setRows, rowsLoading, selectedRowIds, setSelectedRowIds } = useTrainingRows(trainingId, user);
@@ -53,9 +52,6 @@ export default function AdminEntrainementDetailPage() {
   const [icon, setIcon] = useState("/icons/plus.svg");
   const [iconSrc, setIconSrc] = useState("/icons/colonne.svg");
   const [dragActive, setDragActive] = useState(false);
-  const [showProgramDeleteModal, setShowProgramDeleteModal] = useState(false);
-  const [programIdToDelete, setProgramIdToDelete] = useState<string | null>(null);
-
   useEffect(() => {
     if (searchParams?.get("new") === "1") {
       setEditing(true);
@@ -123,8 +119,20 @@ export default function AdminEntrainementDetailPage() {
               }
             }}
         >
-          <img src="/icons/chevron_left.svg" alt="Retour" className="h-3 w-2 mr-2 group-hover:hidden" />
-          <img src="/icons/chevron_left_hover.svg" alt="Retour (hover)" className="h-3 w-2 mr-2 hidden group-hover:inline" />
+          <Image
+            src="/icons/chevron_left.svg"
+            alt="Retour"
+            width={8}
+            height={12}
+            className="h-3 w-2 mr-2 group-hover:hidden"
+          />
+          <Image
+            src="/icons/chevron_left_hover.svg"
+            alt="Retour (hover)"
+            width={8}
+            height={12}
+            className="h-3 w-2 mr-2 hidden group-hover:inline"
+          />
           Entraînements
         </div>
 

--- a/src/app/admin/program/page.tsx
+++ b/src/app/admin/program/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
@@ -37,7 +37,7 @@ export default function AdminProgramPage() {
     setShowActionsBar(selectedIds.length > 0);
   }, [selectedIds]);
 
-  const fetchPrograms = async () => {
+  const fetchPrograms = useCallback(async () => {
     setLoading(true);
     const { data: rawPrograms, error } = await supabase.rpc("programs_admin_with_count");
     if (error) {
@@ -93,11 +93,11 @@ export default function AdminProgramPage() {
     setSelectedIds([]);
     setShowActionsBar(false);
     setLoading(false);
-  };
+  }, [sortBy, sortDirection, supabase]);
 
   useEffect(() => {
     fetchPrograms();
-  }, [sortBy, sortDirection]);
+  }, [fetchPrograms]);
 
   const handleSort = (column: string) => {
     if (sortBy === column) {

--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -16,7 +16,6 @@ export default function ConnexionPage() {
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
-  const [error, setError] = useState("");
   const [errorCode, setErrorCode] = useState<null | "invalid_credentials" | "generic">(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -93,7 +92,6 @@ export default function ConnexionPage() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (submitting) return;
-    setError("");
     setErrorCode(null);
     setSubmitting(true);
 
@@ -117,10 +115,8 @@ export default function ConnexionPage() {
       });
       if (error) {
         if (error.message === "Invalid login credentials") {
-          setError("Email ou mot de passe incorrect.");
           setErrorCode("invalid_credentials");
         } else {
-          setError("Une erreur est survenue.");
           setErrorCode("generic");
         }
         setSubmitting(false);
@@ -157,7 +153,6 @@ export default function ConnexionPage() {
 
       window.location.href = nextTarget;
     } catch {
-      setError("Une erreur est survenue.");
       setErrorCode("generic");
       setSubmitting(false);
     }
@@ -324,16 +319,20 @@ export default function ConnexionPage() {
                   onChange={(e) => setRememberMe(e.target.checked)}
                   className="peer sr-only"
                 />
-                <img
+                <Image
                   src="/icons/checkbox_unchecked.svg"
                   alt=""
                   aria-hidden="true"
+                  width={15}
+                  height={15}
                   className="absolute inset-0 w-[15px] h-[15px] peer-checked:hidden"
                 />
-                <img
+                <Image
                   src="/icons/checkbox_checked.svg"
                   alt=""
                   aria-hidden="true"
+                  width={15}
+                  height={15}
                   className="absolute inset-0 w-[15px] h-[15px] hidden peer-checked:block"
                 />
               </div>

--- a/src/app/entrainements/[id]/page.tsx
+++ b/src/app/entrainements/[id]/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams, useParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { useMemo } from "react";
 import { useUser } from "@/context/UserContext";
-import { Row } from "@/types/training";
 import EditableTitle from "@/components/EditableTitle";
 import TrainingTable from "@/components/TrainingTable";
 import TableActionsBar from "@/components/TableActionsBar";
@@ -21,6 +19,7 @@ import { useTrainingColumns } from "@/utils/useTrainingColumns";
 import { useSeriesChange } from "@/utils/useSeriesChange";
 import { useCheckboxChange } from "@/utils/useCheckboxChange";
 import { useIconHover } from "@/utils/useIconHover";
+import Image from "next/image";
 
 export default function AdminEntrainementDetailPage() {
   const params = useParams();
@@ -32,8 +31,8 @@ export default function AdminEntrainementDetailPage() {
 
   // ✅ States
   const [editing, setEditing] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
-  const [hoveredSuperset, setHoveredSuperset] = useState(false);
+  const [, setIsEditing] = useState(false);
+  const [, setHoveredSuperset] = useState(false);
 
   // ✅ Training data
   const { rows, setRows, rowsLoading, selectedRowIds, setSelectedRowIds } = useTrainingRows(trainingId, user);
@@ -53,9 +52,6 @@ export default function AdminEntrainementDetailPage() {
   const [icon, setIcon] = useState("/icons/plus.svg");
   const [iconSrc, setIconSrc] = useState("/icons/colonne.svg");
   const [dragActive, setDragActive] = useState(false);
-  const [showProgramDeleteModal, setShowProgramDeleteModal] = useState(false);
-  const [programIdToDelete, setProgramIdToDelete] = useState<string | null>(null);
-
   useEffect(() => {
     if (searchParams?.get("new") === "1") {
       setEditing(true);
@@ -123,8 +119,20 @@ export default function AdminEntrainementDetailPage() {
               }
             }}
         >
-          <img src="/icons/chevron_left.svg" alt="Retour" className="h-3 w-2 mr-2 group-hover:hidden" />
-          <img src="/icons/chevron_left_hover.svg" alt="Retour (hover)" className="h-3 w-2 mr-2 hidden group-hover:inline" />
+          <Image
+            src="/icons/chevron_left.svg"
+            alt="Retour"
+            width={8}
+            height={12}
+            className="h-3 w-2 mr-2 group-hover:hidden"
+          />
+          <Image
+            src="/icons/chevron_left_hover.svg"
+            alt="Retour (hover)"
+            width={8}
+            height={12}
+            className="h-3 w-2 mr-2 hidden group-hover:inline"
+          />
           Entraînements
         </div>
 

--- a/src/app/entrainements/page.tsx
+++ b/src/app/entrainements/page.tsx
@@ -20,7 +20,6 @@ import {
   DragOverEvent,
 } from "@dnd-kit/core";
 import { DragOverlay } from "@dnd-kit/core";
-import SortableItem from "@/components/TrainingList/SortableItem";
 import { notifyTrainingChange } from "@/components/ProgramEditor";
 
 export default function EntrainementsPage() {
@@ -71,12 +70,12 @@ export default function EntrainementsPage() {
   useEffect(() => {
     const channel = new BroadcastChannel("glift-refresh");
     channel.onmessage = (event) => {
-      if (event.data === 'refresh-all-programs') {
+      if (event.data === "refresh-all-programs") {
         fetchProgramsWithTrainings();
       }
     };
     return () => channel.close();
-  }, []);
+  }, [fetchProgramsWithTrainings]);
 
   const programsToRender = (programsDuringDrag ?? programs).filter((p, i) => {
     const isEmpty = p.trainings.length === 0;

--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -1,7 +1,7 @@
 // src/app/inscription/informations/page.tsx
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import StepDots from "@/components/onboarding/StepDots";
 import Spinner from "@/components/ui/Spinner";
@@ -64,31 +64,6 @@ export default function InformationsPage() {
   const isFormValid = Boolean(
     gender && birthDay && birthMonth && birthYear && experience && mainGoal
   );
-
-  // Listes (si ton BirthDateField les utilise)
-  const days = useMemo(
-    () => ["", ...Array.from({ length: 31 }, (_, i) => String(i + 1).padStart(2, "0"))],
-    []
-  );
-  const months = [
-    { value: "", label: "Mois" },
-    { value: "01", label: "Janvier" },
-    { value: "02", label: "Février" },
-    { value: "03", label: "Mars" },
-    { value: "04", label: "Avril" },
-    { value: "05", label: "Mai" },
-    { value: "06", label: "Juin" },
-    { value: "07", label: "Juillet" },
-    { value: "08", label: "Août" },
-    { value: "09", label: "Septembre" },
-    { value: "10", label: "Octobre" },
-    { value: "11", label: "Novembre" },
-    { value: "12", label: "Décembre" },
-  ];
-  const yearsList = useMemo(() => {
-    const now = new Date().getFullYear();
-    return ["", ...Array.from({ length: 101 }, (_, i) => String(now - i))];
-  }, []);
 
   // Handlers BirthDateField (et marquage touched)
   const setBDay = (v: string) => {

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Spinner from "@/components/ui/Spinner";
 import Tooltip from "@/components/Tooltip";
@@ -59,23 +60,6 @@ export default function InscriptionPage() {
     passwordTouched && !passwordFocused && password !== "" && !isPasswordValidFormat;
 
   const isFormValid = accepted && isPrenomFieldValid && isEmailValidFormat && isPasswordValidFormat;
-
-  const resetForm = () => {
-    setPrenom("");
-    setPrenomTouched(false);
-    setPrenomFocused(false);
-
-    setEmail("");
-    setEmailTouched(false);
-    setEmailFocused(false);
-
-    setPassword("");
-    setPasswordTouched(false);
-    setPasswordFocused(false);
-
-    setAccepted(false);
-    setShowPassword(false);
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -163,7 +147,7 @@ export default function InscriptionPage() {
     return (
       <div className="flex justify-between items-center">
         <span className={textColor}>{text}</span>
-        <img src={iconSrc} alt="État" className="w-[16px] h-[16px]" />
+        <Image src={iconSrc} alt="État" width={16} height={16} className="w-[16px] h-[16px]" />
       </div>
     );
   };
@@ -322,9 +306,11 @@ export default function InscriptionPage() {
                   className="absolute right-3 top-1/2 -translate-y-1/2"
                   aria-label={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
                 >
-                  <img
+                  <Image
                     src={showPassword ? "/icons/masque_defaut.svg" : "/icons/visible_defaut.svg"}
                     alt=""
+                    width={25}
+                    height={25}
                     className="w-[25px] h-[25px]"
                   />
                   <span className="sr-only">
@@ -366,16 +352,20 @@ export default function InscriptionPage() {
                   onChange={(e) => setAccepted(e.target.checked)}
                   className="peer sr-only"
                 />
-                <img
+                <Image
                   src="/icons/checkbox_unchecked.svg"
                   alt=""
                   aria-hidden="true"
+                  width={15}
+                  height={15}
                   className="absolute inset-0 w-[15px] h-[15px] peer-checked:hidden"
                 />
-                <img
+                <Image
                   src="/icons/checkbox_checked.svg"
                   alt=""
                   aria-hidden="true"
+                  width={15}
+                  height={15}
                   className="absolute inset-0 w-[15px] h-[15px] hidden peer-checked:block"
                 />
               </div>
@@ -415,9 +405,11 @@ export default function InscriptionPage() {
                 </span>
               ) : (
                 <>
-                  <img
+                  <Image
                     src="/icons/cadena_defaut.svg"
                     alt="Icône cadenas"
+                    width={20}
+                    height={20}
                     className={`w-[20px] h-[20px] mr-1 transition-colors ${isFormValid ? "invert brightness-0" : ""}`}
                   />
                   Créer mon compte

--- a/src/app/inscription/paiement/page.tsx
+++ b/src/app/inscription/paiement/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 import StepDots from "@/components/onboarding/StepDots";
@@ -97,17 +98,21 @@ export default function PaiementPage() {
               className="peer sr-only"
             />
             {/* non coché → icône 'unchecked' */}
-            <img
+            <Image
               src="/icons/checkbox_unchecked.svg"
               alt=""
               aria-hidden="true"
+              width={15}
+              height={15}
               className="absolute inset-0 w-[15px] h-[15px] peer-checked:hidden"
             />
             {/* coché → icône 'checked' */}
-            <img
+            <Image
               src="/icons/checkbox_checked.svg"
               alt=""
               aria-hidden="true"
+              width={15}
+              height={15}
               className="absolute inset-0 w-[15px] h-[15px] hidden peer-checked:block"
             />
           </div>
@@ -138,10 +143,12 @@ export default function PaiementPage() {
             ) : (
               <>
                 Démarrer mon abonnement
-                <img
+                <Image
                   src={arrowIcon}
                   alt=""
                   aria-hidden="true"
+                  width={25}
+                  height={25}
                   className="w-[25px] h-[25px] ml-1"
                 />
               </>
@@ -151,15 +158,19 @@ export default function PaiementPage() {
 
         {/* Liseré “Paiement 100% sécurisé par Stripe” */}
         <div className="mt-5 flex items-center justify-center gap-2 text-[12px] font-semibold text-[#5D6494]">
-          <img
+          <Image
             src="/icons/cadena_stripe.svg"
             alt="Sécurisé"
+            width={16}
+            height={16}
             className="h-[16px] w-auto mt-[-3px]"
           />
           <span>Paiement 100% sécurisé par</span>
-          <img
+          <Image
             src="/icons/logo_stripe.svg"
             alt="Stripe"
+            width={48}
+            height={16}
             className="h-[16px] w-auto ml-[-3px]"
           />
         </div>


### PR DESCRIPTION
## Summary
- convert admin create/edit pages to memoize Supabase fetch helpers and satisfy hook dependencies
- remove unused training state while switching admin and user training headers to next/image icons
- replace inline <img> usages and unused helpers in authentication and onboarding flows to address eslint warnings

## Testing
- npm run lint *(fails: existing lint warnings in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eb743a5c832eabcf805bf7d1575d