### PR TITLE
Ensure AddProgramButton component remains removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # OS files
 Thumbs.db
+
+# Ensure removed components stay untracked
+src/components/AddProgramButton.tsx


### PR DESCRIPTION
## Summary
- prevent the deleted `AddProgramButton` component from being reintroduced by ignoring the file path

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9301e81c4832eb6b173cefeb20e39