### PR TITLE
Fix drag and chevron icon alignment on training pages

### DIFF
--- a/src/components/TrainingRow.tsx
+++ b/src/components/TrainingRow.tsx
@@ -107,7 +107,7 @@ export default function TrainingRow({
         className="px-0 py-0"
         style={{ maxWidth: "60px", width: "60px", backgroundColor: row.checked ? "#F4F5FE" : "transparent" }}
       >
-        <div className="flex items-center h-10 justify-end border-t border-[#ECE9F1]">
+        <div className="flex items-center h-10 justify-start border-t border-[#ECE9F1] pl-3">
           <Image
             {...dragListeners}
             src={row.iconHovered ? "/icons/drag_hover.svg" : "/icons/drag.svg"}
@@ -203,14 +203,26 @@ export default function TrainingRow({
               className="w-5 h-3 flex items-center justify-center mb-1"
               disabled={row.series >= 6}
             >
-              <Image src="/icons/chevron_training_up.svg" alt="+" width={20} height={12} />
+              <Image
+                src="/icons/chevron_training_up.svg"
+                alt="+"
+                width={20}
+                height={12}
+                className="w-5 h-3"
+              />
             </button>
             <button
               onClick={() => handleDecrementSeries(index)}
               className="w-5 h-3 flex items-center justify-center"
               disabled={row.series <= 1}
             >
-              <Image src="/icons/chevron_training_down.svg" alt="-" width={20} height={12} />
+              <Image
+                src="/icons/chevron_training_down.svg"
+                alt="-"
+                width={20}
+                height={12}
+                className="w-5 h-3"
+              />
             </button>
           </div>
         </div>
@@ -325,14 +337,26 @@ export default function TrainingRow({
                     onClick={() => handleEffortChange(index, subIndex, "up")}
                     disabled={eff === "trop facile"}
                   >
-                    <Image src="/icons/chevron_training_up.svg" alt="+" width={20} height={12} />
+                    <Image
+                      src="/icons/chevron_training_up.svg"
+                      alt="+"
+                      width={20}
+                      height={12}
+                      className="w-5 h-3"
+                    />
                   </button>
                   <button
                     className="w-5 h-3 flex items-center justify-center"
                     onClick={() => handleEffortChange(index, subIndex, "down")}
                     disabled={eff === "trop dur"}
                   >
-                    <Image src="/icons/chevron_training_down.svg" alt="-" width={20} height={12} />
+                    <Image
+                      src="/icons/chevron_training_down.svg"
+                      alt="-"
+                      width={20}
+                      height={12}
+                      className="w-5 h-3"
+                    />
                   </button>
                 </div>
               </div>

--- a/src/components/TrainingRowOverlay.tsx
+++ b/src/components/TrainingRowOverlay.tsx
@@ -33,7 +33,7 @@ export default function TrainingRowOverlay({ row, columns }: Props) {
         className="px-0 py-0"
         style={{ maxWidth: "60px", width: "60px", backgroundColor: row.checked ? "#F4F5FE" : "transparent" }}
       >
-        <div className="flex items-center h-10 justify-end border-t border-[#ECE9F1]">
+        <div className="flex items-center h-10 justify-start border-t border-[#ECE9F1] pl-3">
           <Image
             src={row.iconHovered ? "/icons/drag_hover.svg" : "/icons/drag.svg"}
             alt="Icone"
@@ -88,10 +88,22 @@ export default function TrainingRowOverlay({ row, columns }: Props) {
           <span className="w-9 h-8 text-left px-2 py-1 font-semibold text-[#5D6494]" style={{ lineHeight: "1.5", display: "flex", alignItems: "center", justifyContent: "center" }}>{row.series}</span>
           <div className="flex flex-col items-center justify-between">
             <div className="w-5 h-3 flex items-center justify-center mb-1">
-              <Image src="/icons/chevron_training_up.svg" alt="Up" width={20} height={12} />
+              <Image
+                src="/icons/chevron_training_up.svg"
+                alt="Up"
+                width={20}
+                height={12}
+                className="w-5 h-3"
+              />
             </div>
             <div className="w-5 h-3 flex items-center justify-center">
-              <Image src="/icons/chevron_training_down.svg" alt="Down" width={20} height={12} />
+              <Image
+                src="/icons/chevron_training_down.svg"
+                alt="Down"
+                width={20}
+                height={12}
+                className="w-5 h-3"
+              />
             </div>
           </div>
         </div>
@@ -202,10 +214,22 @@ export default function TrainingRowOverlay({ row, columns }: Props) {
                 </div>
                 <div className="flex flex-col items-center ml-auto">
                   <div className="w-5 h-3 flex items-center justify-center mb-1">
-                    <Image src="/icons/chevron_training_up.svg" alt="Up" width={20} height={12} />
+                    <Image
+                      src="/icons/chevron_training_up.svg"
+                      alt="Up"
+                      width={20}
+                      height={12}
+                      className="w-5 h-3"
+                    />
                   </div>
                   <div className="w-5 h-3 flex items-center justify-center">
-                    <Image src="/icons/chevron_training_down.svg" alt="Down" width={20} height={12} />
+                    <Image
+                      src="/icons/chevron_training_down.svg"
+                      alt="Down"
+                      width={20}
+                      height={12}
+                      className="w-5 h-3"
+                    />
                   </div>
                 </div>
               </div>

--- a/src/components/training/DragPreviewItem.tsx
+++ b/src/components/training/DragPreviewItem.tsx
@@ -13,7 +13,7 @@ export default function DragPreviewItem({ training }: { training: Training }) {
   return (
     <div className="w-[270px] h-[60px] bg-white border border-[#ECE9F1] rounded-[5px] flex items-center px-4 text-[#3A416F] font-semibold text-[16px] shadow-[0px_1px_15px_rgba(0,0,0,0.08)] cursor-grabbing select-none">
       <div className="relative w-full flex items-center justify-center">
-        <div className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-[25px] h-[25px] z-10 group relative">
+        <div className="absolute left-[-16px] top-1/2 -translate-y-1/2 w-[25px] h-[25px] z-10 group relative">
           <Image
             src="/icons/drag.svg"
             alt="Déplacer"

--- a/src/components/training/SortableItem.tsx
+++ b/src/components/training/SortableItem.tsx
@@ -103,7 +103,7 @@ export default function SortableItem({
       >
         <div className="relative w-full flex items-center justify-center">
           <div
-            className={`absolute left-[-6px] top-1/2 -translate-y-1/2 w-[25px] h-[25px] z-10 group relative ${
+            className={`absolute left-[-16px] top-1/2 -translate-y-1/2 w-[25px] h-[25px] z-10 group relative ${
               dragDisabled ? 'cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'
             } bg-[rgba(0,0,0,0.001)]`}
             {...(!dragDisabled ? listeners : {})}


### PR DESCRIPTION
## Summary
- realign the drag handle in training cards so it sits flush with the card edge
- restore left alignment of drag controls inside training rows and normalize chevron sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9414a18e8832eb8094227f9997e81