### PR TITLE
Refactor account form state management

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -1,509 +1,50 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
 import type { User } from "@supabase/supabase-js"
-import { createClient } from "@/lib/supabaseClient"
-import DropdownField from "./fields/DropdownField"
-import ToggleField from "./fields/ToggleField"
-import TextField from "./fields/TextField"
+
+import {
+  COUNTRIES,
+  EXPERIENCE_OPTIONS,
+  GENDER_OPTIONS,
+  MAIN_GOALS,
+  SUPPLEMENTS_OPTIONS,
+  TRAINING_PLACES,
+  WEEKLY_SESSIONS_OPTIONS,
+} from "./constants"
+import { useAccountForm } from "./hooks/useAccountForm"
 import BirthDateField from "./fields/BirthDateField"
+import DropdownField from "./fields/DropdownField"
 import SubmitButton from "./fields/SubmitButton"
-
-const supabase = createClient()
-
-const countries = ['France', 'Belgique', 'Suisse', 'Canada', 'Autre']
-const goals = ['Perte de poids', 'Prise de muscle', 'Remise en forme', 'Performance']
-const trainingPlaces = ['Salle', 'Domicile', 'Les deux']
-
-type TouchedState = {
-  name: boolean
-  birthDay: boolean
-  birthMonth: boolean
-  birthYear: boolean
-  gender: boolean
-  country: boolean
-  experience: boolean
-  mainGoal: boolean
-  trainingPlace: boolean
-  weeklySessions: boolean
-  supplements: boolean
-}
-
-function useLatchedTouched(
-  current: TouchedState,
-  prevRef: React.MutableRefObject<TouchedState>,
-  resetCounter: number
-) {
-  const [latched, setLatched] = useState<TouchedState>({ ...current })
-
-  useEffect(() => {
-    if (resetCounter > 0) {
-      prevRef.current = { ...current }
-      setLatched({ ...current })
-      return
-    }
-    setLatched((prev) => {
-      const next: TouchedState = { ...current }
-      for (const key of Object.keys(prev) as Array<keyof TouchedState>) {
-        if (prev[key] && !current[key]) {
-          next[key] = true
-        }
-      }
-      prevRef.current = next
-      return next
-    })
-  }, [current, prevRef, resetCounter])
-
-  return latched
-}
-
-function useSuccessMessages(params: {
-  latchedTouched: TouchedState
-  isEditingName: boolean
-  name: string
-  initialName: string
-  country: string
-  initialCountry: string
-  experience: string
-  initialExperience: string
-  mainGoal: string
-  initialMainGoal: string
-  trainingPlace: string
-  initialTrainingPlace: string
-  weeklySessions: string
-  initialWeeklySessions: string
-  supplements: string
-  initialSupplements: string
-  gender: string
-  initialGender: string
-  currentBirthDate: string
-  initialBirthDate: string
-  isBirthDateValid: boolean
-  successRef: React.MutableRefObject<Record<string, string>>
-  suppress: boolean
-}) {
-  const {
-    latchedTouched,
-    isEditingName,
-    name,
-    initialName,
-    country,
-    initialCountry,
-    experience,
-    initialExperience,
-    mainGoal,
-    initialMainGoal,
-    trainingPlace,
-    initialTrainingPlace,
-    weeklySessions,
-    initialWeeklySessions,
-    supplements,
-    initialSupplements,
-    gender,
-    initialGender,
-    currentBirthDate,
-    initialBirthDate,
-    isBirthDateValid,
-    successRef,
-    suppress,
-  } = params
-
-  return useMemo(() => {
-    if (suppress) return {}
-
-    const msgs: Record<string, string> = { ...successRef.current }
-
-    if (latchedTouched.gender && gender && gender !== initialGender) {
-      msgs.gender =
-        gender === 'Homme'
-          ? 'Men power !'
-          : gender === 'Femme'
-          ? 'Women power !'
-          : "C'est noté !"
-    } else {
-      delete msgs.gender
-    }
-
-    if (
-      latchedTouched.name &&
-      !isEditingName &&
-      name.trim().length > 1 &&
-      name.trim() !== initialName.trim()
-    ) {
-      msgs.name = `Très bien, à partir de maintenant ce sera ${name.trim()} !`
-    } else {
-      delete msgs.name
-    }
-
-    if (latchedTouched.country && country && country !== initialCountry) {
-      msgs.country = "Ok, c'est un beau pays !"
-    } else {
-      delete msgs.country
-    }
-
-    if (latchedTouched.experience && experience && experience !== initialExperience) {
-      msgs.experience = "Merci, on va passer les prochaines années ensemble !"
-    } else {
-      delete msgs.experience
-    }
-
-    if (latchedTouched.mainGoal && mainGoal && mainGoal !== initialMainGoal) {
-      msgs.mainGoal = "C'est un bel objectif, let's go !"
-    } else {
-      delete msgs.mainGoal
-    }
-
-    if (
-      latchedTouched.trainingPlace &&
-      trainingPlace &&
-      trainingPlace !== initialTrainingPlace
-    ) {
-      msgs.trainingPlace = "Très bien, c'est noté !"
-    } else {
-      delete msgs.trainingPlace
-    }
-
-    if (
-      latchedTouched.weeklySessions &&
-      weeklySessions &&
-      weeklySessions !== initialWeeklySessions
-    ) {
-      msgs.weeklySessions = "Parfait, on va en tirer le maximum !"
-    } else {
-      delete msgs.weeklySessions
-    }
-
-    if (
-      latchedTouched.supplements &&
-      supplements !== '' &&
-      supplements !== initialSupplements
-    ) {
-      msgs.supplements = "Top, merci pour l'info !"
-    } else {
-      delete msgs.supplements
-    }
-
-    if (isBirthDateValid && currentBirthDate && currentBirthDate !== initialBirthDate) {
-      msgs.birthDate = "Super, maintenant on connaît la date de ton anniversaire !"
-    } else {
-      delete msgs.birthDate
-    }
-
-    successRef.current = msgs
-    return msgs
-  }, [
-    latchedTouched,
-    isEditingName,
-    name,
-    initialName,
-    country,
-    initialCountry,
-    experience,
-    initialExperience,
-    mainGoal,
-    initialMainGoal,
-    trainingPlace,
-    initialTrainingPlace,
-    weeklySessions,
-    initialWeeklySessions,
-    supplements,
-    initialSupplements,
-    gender,
-    initialGender,
-    currentBirthDate,
-    initialBirthDate,
-    isBirthDateValid,
-    successRef,
-    suppress,
-  ])
-}
-
-const buildBirthDate = (birthDate: {
-  birthDay: string
-  birthMonth: string
-  birthYear: string
-}) => {
-  if (birthDate.birthYear && birthDate.birthMonth && birthDate.birthDay) {
-    return `${birthDate.birthYear}-${birthDate.birthMonth}-${birthDate.birthDay}`
-  }
-  return ''
-}
+import TextField from "./fields/TextField"
+import ToggleField from "./fields/ToggleField"
 
 export default function MesInformationsForm({ user }: { user: User | null }) {
-  const prevLatchedRef = useRef<TouchedState>({
-    name: false,
-    birthDay: false,
-    birthMonth: false,
-    birthYear: false,
-    gender: false,
-    country: false,
-    experience: false,
-    mainGoal: false,
-    trainingPlace: false,
-    weeklySessions: false,
-    supplements: false,
-  })
-
-  const successRef = useRef<Record<string, string>>({})
-  const [suppressSuccess, setSuppressSuccess] = useState(false)
-  const [latchedResetCounter, setLatchedResetCounter] = useState(0)
-
-  const initialMetadataRef = useRef(user?.user_metadata || {})
-  useEffect(() => {
-    if (user?.user_metadata) {
-      initialMetadataRef.current = user.user_metadata
-    }
-  }, [user?.user_metadata])
-
-  const initial = (field: string) => initialMetadataRef.current?.[field] || ''
-
-  const initialName = initial('name') as string
-  const initialCountry = initial('country') as string
-  const initialExperience = initial('experience_years') as string
-  const initialMainGoal = initial('main_goal') as string
-  const initialTrainingPlace = initial('training_place') as string
-  const initialWeeklySessions = initial('weekly_sessions') as string
-  const initialSupplements = initial('supplements') as string
-  const initialGender = initial('gender') as string
-  const rawInitialBirth = initial('birth_date')
-  const initialBirthDate = typeof rawInitialBirth === 'string' ? rawInitialBirth : ''
-  const [initialBirthYear, initialBirthMonth, initialBirthDay] =
-    initialBirthDate.includes('-') ? initialBirthDate.split('-') : ['', '', '']
-
-  const [name, setName] = useState(initialName)
-  const [birthDate, setBirthDate] = useState(() => {
-    if (initialBirthDate.includes('-')) {
-      const [year, month, day] = initialBirthDate.split('-')
-      return { birthDay: day, birthMonth: month, birthYear: year }
-    }
-    return { birthDay: '', birthMonth: '', birthYear: '' }
-  })
-  const [gender, setGender] = useState(initialGender)
-  const [country, setCountry] = useState(initialCountry)
-  const [experience, setExperience] = useState(initialExperience)
-  const [mainGoal, setMainGoal] = useState(initialMainGoal)
-  const [trainingPlace, setTrainingPlace] = useState(initialTrainingPlace)
-  const [weeklySessions, setWeeklySessions] = useState(initialWeeklySessions)
-  const [supplements, setSupplements] = useState(initialSupplements)
-  const [loading, setLoading] = useState(false)
-  const [isEditingName, setIsEditingName] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const [touched, setTouched] = useState<TouchedState>({
-    name: false,
-    birthDay: false,
-    birthMonth: false,
-    birthYear: false,
-    gender: false,
-    country: false,
-    experience: false,
-    mainGoal: false,
-    trainingPlace: false,
-    weeklySessions: false,
-    supplements: false,
-  })
-
-  const latchedTouched = useLatchedTouched(touched, prevLatchedRef, latchedResetCounter)
-
-  const currentBirthDate = buildBirthDate(birthDate)
-
-  const isBirthDateValid = Boolean(
-    birthDate.birthDay &&
-      birthDate.birthMonth &&
-      birthDate.birthYear &&
-      (latchedTouched.birthDay || latchedTouched.birthMonth || latchedTouched.birthYear)
-  )
-
-  const [initialValues, setInitialValues] = useState({
-    name: initialName,
-    country: initialCountry,
-    experience: initialExperience,
-    mainGoal: initialMainGoal,
-    trainingPlace: initialTrainingPlace,
-    weeklySessions: initialWeeklySessions,
-    supplements: initialSupplements,
-    gender: initialGender,
-    birthDate: initialBirthDate,
-  })
-
-  const successMessages = useSuccessMessages({
+  const {
+    values,
+    updateValue,
+    updateBirthDatePart,
+    markTouched,
     latchedTouched,
-    isEditingName,
-    name,
-    initialName,
-    country,
-    initialCountry,
-    experience,
-    initialExperience,
-    mainGoal,
-    initialMainGoal,
-    trainingPlace,
-    initialTrainingPlace,
-    weeklySessions,
-    initialWeeklySessions,
-    supplements,
-    initialSupplements,
-    gender,
-    initialGender,
-    currentBirthDate,
-    initialBirthDate: initialValues.birthDate,
-    isBirthDateValid,
-    successRef,
-    suppress: suppressSuccess,
-  })
-
-  const computeHasChanges = () => {
-    return (
-      name !== initialValues.name ||
-      country !== initialValues.country ||
-      experience !== initialValues.experience ||
-      mainGoal !== initialValues.mainGoal ||
-      trainingPlace !== initialValues.trainingPlace ||
-      weeklySessions !== initialValues.weeklySessions ||
-      supplements !== initialValues.supplements ||
-      gender !== initialValues.gender ||
-      currentBirthDate !== initialValues.birthDate
-    )
-  }
-  const hasChanges = computeHasChanges()
-
-  const clearSuccessAndBorders = () => {
-    successRef.current = {}
-    setTouched({
-      name: false,
-      birthDay: false,
-      birthMonth: false,
-      birthYear: false,
-      gender: false,
-      country: false,
-      experience: false,
-      mainGoal: false,
-      trainingPlace: false,
-      weeklySessions: false,
-      supplements: false,
-    })
-    prevLatchedRef.current = {
-      name: false,
-      birthDay: false,
-      birthMonth: false,
-      birthYear: false,
-      gender: false,
-      country: false,
-      experience: false,
-      mainGoal: false,
-      trainingPlace: false,
-      weeklySessions: false,
-      supplements: false,
-    }
-    setSuppressSuccess(true)
-    setLatchedResetCounter((c) => c + 1)
-  }
-
-  const resetSuppress = () => {
-    if (suppressSuccess) setSuppressSuccess(false)
-  }
-
-  const handleSubmit = async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const { error } = await supabase.auth.updateUser({
-        data: {
-          name,
-          birth_date: currentBirthDate || null,
-          gender,
-          country,
-          experience_years: experience,
-          main_goal: mainGoal,
-          training_place: trainingPlace,
-          weekly_sessions: weeklySessions,
-          supplements,
-        },
-      })
-      if (error) throw error
-
-      const updatedInitials = {
-        name,
-        country,
-        experience,
-        mainGoal,
-        trainingPlace,
-        weeklySessions,
-        supplements,
-        gender,
-        birthDate: currentBirthDate,
-      }
-
-      initialMetadataRef.current = {
-        ...(initialMetadataRef.current || {}),
-        name,
-        country,
-        experience_years: experience,
-        main_goal: mainGoal,
-        training_place: trainingPlace,
-        weekly_sessions: weeklySessions,
-        supplements,
-        gender,
-        birth_date: currentBirthDate || null,
-      }
-
-      setInitialValues({
-        name: updatedInitials.name,
-        country: updatedInitials.country,
-        experience: updatedInitials.experience,
-        mainGoal: updatedInitials.mainGoal,
-        trainingPlace: updatedInitials.trainingPlace,
-        weeklySessions: updatedInitials.weeklySessions,
-        supplements: updatedInitials.supplements,
-        gender: updatedInitials.gender,
-        birthDate: updatedInitials.birthDate,
-      })
-
-      setTouched({
-        name: false,
-        birthDay: false,
-        birthMonth: false,
-        birthYear: false,
-        gender: false,
-        country: false,
-        experience: false,
-        mainGoal: false,
-        trainingPlace: false,
-        weeklySessions: false,
-        supplements: false,
-      })
-      prevLatchedRef.current = {
-        name: false,
-        birthDay: false,
-        birthMonth: false,
-        birthYear: false,
-        gender: false,
-        country: false,
-        experience: false,
-        mainGoal: false,
-        trainingPlace: false,
-        weeklySessions: false,
-        supplements: false,
-      }
-      successRef.current = {}
-      setIsEditingName(false)
-    } catch (e) {
-      console.error('Erreur mise à jour', e)
-      setError('Une erreur est survenue lors de la mise à jour. Veuillez réessayer.')
-    } finally {
-      setLoading(false)
-    }
-  }
+    successMessages,
+    handleSubmit,
+    loading,
+    error,
+    hasChanges,
+    resetSuppress,
+    initialBirthParts,
+    startNameEdition,
+    endNameEdition,
+  } = useAccountForm(user)
 
   return (
     <form
-      onSubmit={(e) => {
-        e.preventDefault()
+      onSubmit={(event) => {
+        event.preventDefault()
         handleSubmit()
       }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault()
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault()
         }
       }}
       className="flex flex-col items-center gap-2"
@@ -516,57 +57,56 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
 
       <ToggleField
         label="Sexe"
-        value={gender}
-        options={['Homme', 'Femme', 'Non binaire']}
-        onChange={(v) => {
+        value={values.gender}
+        options={Array.from(GENDER_OPTIONS)}
+        onChange={(option) => {
           resetSuppress()
-          setGender(gender === v ? '' : v)
-          setTouched((t) => ({ ...t, gender: true }))
+          updateValue("gender", (current) => (current === option ? "" : option))
+          markTouched({ gender: true })
         }}
         touched={latchedTouched.gender}
         setTouched={() => {
           resetSuppress()
-          setTouched((t) => ({ ...t, gender: true }))
+          markTouched({ gender: true })
         }}
         success={successMessages.gender}
       />
 
       <TextField
         label="Prénom"
-        value={name}
-        onChange={(v) => {
+        value={values.name}
+        onChange={(next) => {
           resetSuppress()
-          setName(v)
+          updateValue("name", next)
         }}
         onBlur={() => {
-          setTouched((t) => ({ ...t, name: true }))
-          setIsEditingName(false)
+          endNameEdition()
         }}
         onFocus={() => {
-          setIsEditingName(true)
-          setTouched((t) => ({ ...t, name: false }))
+          resetSuppress()
+          startNameEdition()
         }}
         success={successMessages.name}
       />
 
       <BirthDateField
-        birthDay={birthDate.birthDay}
-        birthMonth={birthDate.birthMonth}
-        birthYear={birthDate.birthYear}
-        setBirthDay={(val) => {
+        birthDay={values.birthDate.birthDay}
+        birthMonth={values.birthDate.birthMonth}
+        birthYear={values.birthDate.birthYear}
+        setBirthDay={(next) => {
           resetSuppress()
-          setBirthDate((prev) => ({ ...prev, birthDay: val }))
-          setTouched((t) => ({ ...t, birthDay: true }))
+          updateBirthDatePart("birthDay", next)
+          markTouched({ birthDay: true })
         }}
-        setBirthMonth={(val) => {
+        setBirthMonth={(next) => {
           resetSuppress()
-          setBirthDate((prev) => ({ ...prev, birthMonth: val }))
-          setTouched((t) => ({ ...t, birthMonth: true }))
+          updateBirthDatePart("birthMonth", next)
+          markTouched({ birthMonth: true })
         }}
-        setBirthYear={(val) => {
+        setBirthYear={(next) => {
           resetSuppress()
-          setBirthDate((prev) => ({ ...prev, birthYear: val }))
-          setTouched((t) => ({ ...t, birthYear: true }))
+          updateBirthDatePart("birthYear", next)
+          markTouched({ birthYear: true })
         }}
         touched={{
           birthDay: latchedTouched.birthDay,
@@ -575,39 +115,39 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
         }}
         setTouched={(partial) => {
           resetSuppress()
-          setTouched((t) => ({
-            ...t,
-            ...(partial.birthDay !== undefined && { birthDay: partial.birthDay }),
-            ...(partial.birthMonth !== undefined && { birthMonth: partial.birthMonth }),
-            ...(partial.birthYear !== undefined && { birthYear: partial.birthYear }),
-          }))
+          markTouched(partial)
         }}
-        successMessage={successMessages.birthDate}
-        initialBirthDay={initialBirthDay}
-        initialBirthMonth={initialBirthMonth}
-        initialBirthYear={initialBirthYear}
+        successMessage={successMessages.birthDate ?? ""}
+        initialBirthDay={initialBirthParts.birthDay}
+        initialBirthMonth={initialBirthParts.birthMonth}
+        initialBirthYear={initialBirthParts.birthYear}
       />
 
-      <TextField label="Email" value={user?.email || ''} disabled />
+      <TextField label="Email" value={user?.email || ""} disabled />
 
-      <div onMouseDown={() => resetSuppress()}>
+      <div
+        onMouseDown={() => {
+          resetSuppress()
+        }}
+      >
         <DropdownField
           label="Pays de résidence"
           placeholder="Sélectionnez un pays"
-          selected={country}
-          onSelect={(v) => {
-            if (v !== country) {
-              resetSuppress()
-              setCountry(v)
-              setTouched((t) => ({ ...t, country: true }))
-            }
+          selected={values.country}
+          onSelect={(option) => {
+            resetSuppress()
+            updateValue("country", option)
+            markTouched({ country: true })
           }}
-          options={countries.map((v) => ({ value: v, label: v }))}
+          options={Array.from(COUNTRIES).map((country) => ({
+            value: country,
+            label: country,
+          }))}
           touched={latchedTouched.country}
-          setTouched={(val) => {
-            if (val) {
+          setTouched={(isTouched) => {
+            if (isTouched) {
               resetSuppress()
-              setTouched((t) => ({ ...t, country: true }))
+              markTouched({ country: true })
             }
           }}
           success={successMessages.country}
@@ -616,39 +156,41 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
 
       <ToggleField
         label="Années de pratique"
-        value={experience}
-        options={['0', '1', '2', '3', '4', '5+']}
-        onChange={(v) => {
+        value={values.experience}
+        options={Array.from(EXPERIENCE_OPTIONS)}
+        onChange={(option) => {
           resetSuppress()
-          setExperience(v)
-          setTouched((t) => ({ ...t, experience: true }))
+          updateValue("experience", option)
+          markTouched({ experience: true })
         }}
         touched={latchedTouched.experience}
         setTouched={() => {
           resetSuppress()
-          setTouched((t) => ({ ...t, experience: true }))
+          markTouched({ experience: true })
         }}
         success={successMessages.experience}
       />
 
-      <div onMouseDown={() => resetSuppress()}>
+      <div
+        onMouseDown={() => {
+          resetSuppress()
+        }}
+      >
         <DropdownField
           label="Objectif principal"
           placeholder="Sélectionnez un objectif"
-          selected={mainGoal}
-          onSelect={(v) => {
-            if (v !== mainGoal) {
-              resetSuppress()
-              setMainGoal(v)
-              setTouched((t) => ({ ...t, mainGoal: true }))
-            }
+          selected={values.mainGoal}
+          onSelect={(option) => {
+            resetSuppress()
+            updateValue("mainGoal", option)
+            markTouched({ mainGoal: true })
           }}
-          options={goals.map((v) => ({ value: v, label: v }))}
+          options={Array.from(MAIN_GOALS).map((goal) => ({ value: goal, label: goal }))}
           touched={latchedTouched.mainGoal}
-          setTouched={(val) => {
-            if (val) {
+          setTouched={(isTouched) => {
+            if (isTouched) {
               resetSuppress()
-              setTouched((t) => ({ ...t, mainGoal: true }))
+              markTouched({ mainGoal: true })
             }
           }}
           success={successMessages.mainGoal}
@@ -657,63 +199,57 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
 
       <ToggleField
         label="Lieu d’entraînement"
-        value={trainingPlace}
-        options={trainingPlaces}
-        onChange={(v) => {
+        value={values.trainingPlace}
+        options={Array.from(TRAINING_PLACES)}
+        onChange={(option) => {
           resetSuppress()
-          setTrainingPlace(v)
-          setTouched((t) => ({ ...t, trainingPlace: true }))
+          updateValue("trainingPlace", option)
+          markTouched({ trainingPlace: true })
         }}
         touched={latchedTouched.trainingPlace}
         setTouched={() => {
           resetSuppress()
-          setTouched((t) => ({ ...t, trainingPlace: true }))
+          markTouched({ trainingPlace: true })
         }}
         success={successMessages.trainingPlace}
       />
 
       <ToggleField
         label="Nombre de sessions par semaine"
-        value={weeklySessions}
-        options={['1', '2', '3', '4', '5', '6+']}
-        onChange={(v) => {
+        value={values.weeklySessions}
+        options={Array.from(WEEKLY_SESSIONS_OPTIONS)}
+        onChange={(option) => {
           resetSuppress()
-          setWeeklySessions(v)
-          setTouched((t) => ({ ...t, weeklySessions: true }))
+          updateValue("weeklySessions", option)
+          markTouched({ weeklySessions: true })
         }}
         touched={latchedTouched.weeklySessions}
         setTouched={() => {
           resetSuppress()
-          setTouched((t) => ({ ...t, weeklySessions: true }))
+          markTouched({ weeklySessions: true })
         }}
         success={successMessages.weeklySessions}
       />
 
       <ToggleField
         label="Prise de compléments alimentaires"
-        value={supplements}
-        options={['Oui', 'Non']}
-        onChange={(v) => {
+        value={values.supplements}
+        options={Array.from(SUPPLEMENTS_OPTIONS)}
+        onChange={(option) => {
           resetSuppress()
-          setSupplements(v)
-          setTouched((t) => ({ ...t, supplements: true }))
+          updateValue("supplements", option)
+          markTouched({ supplements: true })
         }}
         touched={latchedTouched.supplements}
         setTouched={() => {
           resetSuppress()
-          setTouched((t) => ({ ...t, supplements: true }))
+          markTouched({ supplements: true })
         }}
         success={successMessages.supplements}
         className="w-[246px]"
       />
 
-      <SubmitButton
-        loading={loading}
-        disabled={!hasChanges || loading}
-        onClick={() => {
-          clearSuccessAndBorders()
-        }}
-      />
+      <SubmitButton loading={loading} disabled={!hasChanges || loading} />
     </form>
   )
 }

--- a/src/components/account/constants.ts
+++ b/src/components/account/constants.ts
@@ -1,0 +1,18 @@
+export const GENDER_OPTIONS = ['Homme', 'Femme', 'Non binaire'] as const
+
+export const COUNTRIES = ['France', 'Belgique', 'Suisse', 'Canada', 'Autre'] as const
+
+export const EXPERIENCE_OPTIONS = ['0', '1', '2', '3', '4', '5+'] as const
+
+export const MAIN_GOALS = [
+  'Perte de poids',
+  'Prise de muscle',
+  'Remise en forme',
+  'Performance',
+] as const
+
+export const TRAINING_PLACES = ['Salle', 'Domicile', 'Les deux'] as const
+
+export const WEEKLY_SESSIONS_OPTIONS = ['1', '2', '3', '4', '5', '6+'] as const
+
+export const SUPPLEMENTS_OPTIONS = ['Oui', 'Non'] as const

--- a/src/components/account/hooks/useAccountForm.ts
+++ b/src/components/account/hooks/useAccountForm.ts
@@ -1,0 +1,513 @@
+"use client"
+
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import type { User } from "@supabase/supabase-js"
+
+import { createClient } from "@/lib/supabaseClient"
+
+const supabase = createClient()
+
+type BirthDateParts = {
+  birthDay: string
+  birthMonth: string
+  birthYear: string
+}
+
+type FormValues = {
+  name: string
+  gender: string
+  country: string
+  experience: string
+  mainGoal: string
+  trainingPlace: string
+  weeklySessions: string
+  supplements: string
+  birthDate: BirthDateParts
+}
+
+type FlatValues = Omit<FormValues, "birthDate"> & { birthDate: string }
+
+type TouchedState = {
+  name: boolean
+  birthDay: boolean
+  birthMonth: boolean
+  birthYear: boolean
+  gender: boolean
+  country: boolean
+  experience: boolean
+  mainGoal: boolean
+  trainingPlace: boolean
+  weeklySessions: boolean
+  supplements: boolean
+}
+
+type SuccessMessages = Partial<
+  Record<
+    | "gender"
+    | "name"
+    | "country"
+    | "experience"
+    | "mainGoal"
+    | "trainingPlace"
+    | "weeklySessions"
+    | "supplements"
+    | "birthDate",
+    string
+  >
+>
+
+const EMPTY_BIRTH_DATE: BirthDateParts = {
+  birthDay: "",
+  birthMonth: "",
+  birthYear: "",
+}
+
+const defaultTouchedState: TouchedState = {
+  name: false,
+  birthDay: false,
+  birthMonth: false,
+  birthYear: false,
+  gender: false,
+  country: false,
+  experience: false,
+  mainGoal: false,
+  trainingPlace: false,
+  weeklySessions: false,
+  supplements: false,
+}
+
+const createDefaultTouched = (): TouchedState => ({ ...defaultTouchedState })
+
+const parseBirthDate = (raw: unknown): BirthDateParts => {
+  if (typeof raw === "string" && raw.includes("-")) {
+    const [year, month, day] = raw.split("-")
+    return {
+      birthDay: day || "",
+      birthMonth: month || "",
+      birthYear: year || "",
+    }
+  }
+  return { ...EMPTY_BIRTH_DATE }
+}
+
+const formatBirthDate = (parts: BirthDateParts) => {
+  if (parts.birthYear && parts.birthMonth && parts.birthDay) {
+    return `${parts.birthYear}-${parts.birthMonth}-${parts.birthDay}`
+  }
+  return ""
+}
+
+const toFlatValues = (values: FormValues): FlatValues => ({
+  name: values.name,
+  gender: values.gender,
+  country: values.country,
+  experience: values.experience,
+  mainGoal: values.mainGoal,
+  trainingPlace: values.trainingPlace,
+  weeklySessions: values.weeklySessions,
+  supplements: values.supplements,
+  birthDate: formatBirthDate(values.birthDate),
+})
+
+const buildSnapshot = (
+  metadata: Record<string, unknown> | undefined
+): { values: FormValues; flat: FlatValues } => {
+  const safeMetadata = metadata && typeof metadata === "object" ? metadata : {}
+
+  const name = typeof safeMetadata.name === "string" ? safeMetadata.name : ""
+  const gender =
+    typeof safeMetadata.gender === "string" ? safeMetadata.gender : ""
+  const country =
+    typeof safeMetadata.country === "string" ? safeMetadata.country : ""
+  const experience =
+    typeof safeMetadata.experience_years === "string"
+      ? safeMetadata.experience_years
+      : ""
+  const mainGoal =
+    typeof safeMetadata.main_goal === "string" ? safeMetadata.main_goal : ""
+  const trainingPlace =
+    typeof safeMetadata.training_place === "string"
+      ? safeMetadata.training_place
+      : ""
+  const weeklySessions =
+    typeof safeMetadata.weekly_sessions === "string"
+      ? safeMetadata.weekly_sessions
+      : ""
+  const supplements =
+    typeof safeMetadata.supplements === "string"
+      ? safeMetadata.supplements
+      : ""
+
+  const birthDateParts = parseBirthDate(safeMetadata.birth_date)
+
+  const values: FormValues = {
+    name,
+    gender,
+    country,
+    experience,
+    mainGoal,
+    trainingPlace,
+    weeklySessions,
+    supplements,
+    birthDate: birthDateParts,
+  }
+
+  return {
+    values,
+    flat: toFlatValues(values),
+  }
+}
+
+const useLatchedTouched = (
+  touched: TouchedState,
+  resetCounter: number
+): TouchedState => {
+  const prevRef = useRef<TouchedState>(createDefaultTouched())
+  const resetVersion = useRef<number>(resetCounter)
+  const [latched, setLatched] = useState<TouchedState>(touched)
+
+  useEffect(() => {
+    if (resetVersion.current !== resetCounter) {
+      resetVersion.current = resetCounter
+      prevRef.current = { ...touched }
+      setLatched({ ...touched })
+      return
+    }
+
+    setLatched((prev) => {
+      const next: TouchedState = { ...touched }
+      for (const key of Object.keys(prev) as Array<keyof TouchedState>) {
+        if (prev[key] && !touched[key]) {
+          next[key] = true
+        }
+      }
+      prevRef.current = next
+      return next
+    })
+  }, [resetCounter, touched])
+
+  return latched
+}
+
+const useSuccessMessages = (params: {
+  latchedTouched: TouchedState
+  isEditingName: boolean
+  values: FormValues
+  initialFlat: FlatValues
+  isBirthDateValid: boolean
+  successRef: MutableRefObject<Record<string, string>>
+  suppress: boolean
+}): SuccessMessages => {
+  const {
+    latchedTouched,
+    isEditingName,
+    values,
+    initialFlat,
+    isBirthDateValid,
+    successRef,
+    suppress,
+  } = params
+
+  return useMemo(() => {
+    if (suppress) return {}
+
+    const next: Record<string, string> = { ...successRef.current }
+
+    if (latchedTouched.gender && values.gender && values.gender !== initialFlat.gender) {
+      next.gender =
+        values.gender === "Homme"
+          ? "Men power !"
+          : values.gender === "Femme"
+          ? "Women power !"
+          : "C'est noté !"
+    } else {
+      delete next.gender
+    }
+
+    if (
+      latchedTouched.name &&
+      !isEditingName &&
+      values.name.trim().length > 1 &&
+      values.name.trim() !== initialFlat.name.trim()
+    ) {
+      next.name = `Très bien, à partir de maintenant ce sera ${values.name.trim()} !`
+    } else {
+      delete next.name
+    }
+
+    if (latchedTouched.country && values.country && values.country !== initialFlat.country) {
+      next.country = "Ok, c'est un beau pays !"
+    } else {
+      delete next.country
+    }
+
+    if (
+      latchedTouched.experience &&
+      values.experience &&
+      values.experience !== initialFlat.experience
+    ) {
+      next.experience = "Merci, on va passer les prochaines années ensemble !"
+    } else {
+      delete next.experience
+    }
+
+    if (latchedTouched.mainGoal && values.mainGoal && values.mainGoal !== initialFlat.mainGoal) {
+      next.mainGoal = "C'est un bel objectif, let's go !"
+    } else {
+      delete next.mainGoal
+    }
+
+    if (
+      latchedTouched.trainingPlace &&
+      values.trainingPlace &&
+      values.trainingPlace !== initialFlat.trainingPlace
+    ) {
+      next.trainingPlace = "Très bien, c'est noté !"
+    } else {
+      delete next.trainingPlace
+    }
+
+    if (
+      latchedTouched.weeklySessions &&
+      values.weeklySessions &&
+      values.weeklySessions !== initialFlat.weeklySessions
+    ) {
+      next.weeklySessions = "Parfait, on va en tirer le maximum !"
+    } else {
+      delete next.weeklySessions
+    }
+
+    if (
+      latchedTouched.supplements &&
+      values.supplements !== "" &&
+      values.supplements !== initialFlat.supplements
+    ) {
+      next.supplements = "Top, merci pour l'info !"
+    } else {
+      delete next.supplements
+    }
+
+    const currentBirthDate = toFlatValues(values).birthDate
+    if (isBirthDateValid && currentBirthDate && currentBirthDate !== initialFlat.birthDate) {
+      next.birthDate = "Super, maintenant on connaît la date de ton anniversaire !"
+    } else {
+      delete next.birthDate
+    }
+
+    successRef.current = next
+    return next
+  }, [
+    initialFlat.birthDate,
+    initialFlat.country,
+    initialFlat.experience,
+    initialFlat.gender,
+    initialFlat.mainGoal,
+    initialFlat.name,
+    initialFlat.supplements,
+    initialFlat.trainingPlace,
+    initialFlat.weeklySessions,
+    isBirthDateValid,
+    isEditingName,
+    latchedTouched,
+    suppress,
+    successRef,
+    values,
+  ])
+}
+
+const formatErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message) return error.message
+  return "Une erreur est survenue lors de la mise à jour. Veuillez réessayer."
+}
+
+type ValueUpdater = string | ((previous: string) => string)
+
+type BirthDateUpdater = string | ((previous: string) => string)
+
+export const useAccountForm = (user: User | null) => {
+  const snapshot = useMemo(
+    () => buildSnapshot(user?.user_metadata as Record<string, unknown> | undefined),
+    [user?.user_metadata]
+  )
+
+  const [values, setValues] = useState<FormValues>(snapshot.values)
+  const [initialFlat, setInitialFlat] = useState<FlatValues>(snapshot.flat)
+  const [initialBirthParts, setInitialBirthParts] = useState<BirthDateParts>(
+    snapshot.values.birthDate
+  )
+  const [touched, setTouched] = useState<TouchedState>(createDefaultTouched())
+  const [resetCounter, setResetCounter] = useState(0)
+  const latchedTouched = useLatchedTouched(touched, resetCounter)
+
+  const successRef = useRef<Record<string, string>>({})
+  const [suppressSuccess, setSuppressSuccess] = useState(false)
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resetFeedback = useCallback(() => {
+    successRef.current = {}
+    setTouched(createDefaultTouched())
+    setResetCounter((c) => c + 1)
+    setSuppressSuccess(true)
+  }, [])
+
+  useEffect(() => {
+    setValues(snapshot.values)
+    setInitialFlat(snapshot.flat)
+    setInitialBirthParts(snapshot.values.birthDate)
+    setError(null)
+    setIsEditingName(false)
+    resetFeedback()
+  }, [resetFeedback, snapshot])
+
+  const markTouched = useCallback((updates: Partial<TouchedState>) => {
+    setTouched((prev) => ({ ...prev, ...updates }))
+  }, [])
+
+  const resetSuppress = useCallback(() => {
+    setSuppressSuccess((prev) => (prev ? false : prev))
+  }, [])
+
+  const updateValue = useCallback(
+    (field: keyof Omit<FormValues, "birthDate">, input: ValueUpdater) => {
+      setValues((prev) => {
+        const current = prev[field]
+        const nextValue = typeof input === "function" ? input(current) : input
+        if (current === nextValue) return prev
+        return { ...prev, [field]: nextValue }
+      })
+    },
+    []
+  )
+
+  const updateBirthDatePart = useCallback(
+    (part: keyof BirthDateParts, input: BirthDateUpdater) => {
+      setValues((prev) => {
+        const current = prev.birthDate[part]
+        const nextValue = typeof input === "function" ? input(current) : input
+        if (current === nextValue) return prev
+        return {
+          ...prev,
+          birthDate: {
+            ...prev.birthDate,
+            [part]: nextValue,
+          },
+        }
+      })
+    },
+    []
+  )
+
+  const currentFlat = useMemo(() => toFlatValues(values), [values])
+
+  const isBirthDateValid = useMemo(() => {
+    return Boolean(
+      values.birthDate.birthDay &&
+        values.birthDate.birthMonth &&
+        values.birthDate.birthYear &&
+        (latchedTouched.birthDay ||
+          latchedTouched.birthMonth ||
+          latchedTouched.birthYear)
+    )
+  }, [
+    latchedTouched.birthDay,
+    latchedTouched.birthMonth,
+    latchedTouched.birthYear,
+    values.birthDate,
+  ])
+
+  const successMessages = useSuccessMessages({
+    latchedTouched,
+    isEditingName,
+    values,
+    initialFlat,
+    isBirthDateValid,
+    successRef,
+    suppress: suppressSuccess,
+  })
+
+  const hasChanges = useMemo(() => {
+    return (
+      currentFlat.name !== initialFlat.name ||
+      currentFlat.country !== initialFlat.country ||
+      currentFlat.experience !== initialFlat.experience ||
+      currentFlat.mainGoal !== initialFlat.mainGoal ||
+      currentFlat.trainingPlace !== initialFlat.trainingPlace ||
+      currentFlat.weeklySessions !== initialFlat.weeklySessions ||
+      currentFlat.supplements !== initialFlat.supplements ||
+      currentFlat.gender !== initialFlat.gender ||
+      currentFlat.birthDate !== initialFlat.birthDate
+    )
+  }, [currentFlat, initialFlat])
+
+  const handleSubmit = useCallback(async () => {
+    resetFeedback()
+    setLoading(true)
+    setError(null)
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        data: {
+          name: currentFlat.name,
+          birth_date: currentFlat.birthDate || null,
+          gender: currentFlat.gender,
+          country: currentFlat.country,
+          experience_years: currentFlat.experience,
+          main_goal: currentFlat.mainGoal,
+          training_place: currentFlat.trainingPlace,
+          weekly_sessions: currentFlat.weeklySessions,
+          supplements: currentFlat.supplements,
+        },
+      })
+
+      if (updateError) throw updateError
+
+      setInitialFlat({ ...currentFlat })
+      setInitialBirthParts({ ...values.birthDate })
+      successRef.current = {}
+      setIsEditingName(false)
+    } catch (submitError) {
+      console.error("Erreur mise à jour", submitError)
+      setError(formatErrorMessage(submitError))
+    } finally {
+      setLoading(false)
+    }
+  }, [currentFlat, resetFeedback, values.birthDate])
+
+  const startNameEdition = useCallback(() => {
+    setIsEditingName(true)
+    markTouched({ name: false })
+  }, [markTouched])
+
+  const endNameEdition = useCallback(() => {
+    setIsEditingName(false)
+    markTouched({ name: true })
+  }, [markTouched])
+
+  return {
+    values,
+    updateValue,
+    updateBirthDatePart,
+    markTouched,
+    latchedTouched,
+    successMessages,
+    handleSubmit,
+    loading,
+    error,
+    hasChanges,
+    resetSuppress,
+    initialBirthParts,
+    startNameEdition,
+    endNameEdition,
+  }
+}
+
+export type { BirthDateParts, SuccessMessages, TouchedState }


### PR DESCRIPTION
## Summary
- extract shared option lists for the account form into dedicated constants
- introduce a reusable `useAccountForm` hook to centralize account form state, submission, and success messages
- rewrite `MesInformationsForm` to consume the hook and constants for a leaner, easier to maintain component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d94bbf4f08832ea2d60fcac608e128