### PR TITLE
feat: update account toggle design

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -169,6 +169,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
           markTouched({ experience: true })
         }}
         success={successMessages.experience}
+        variant="boxed"
       />
 
       <div
@@ -215,7 +216,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
       />
 
       <ToggleField
-        label="Nombre de sessions par semaine"
+        label="Nombre de séances par semaine"
         value={values.weeklySessions}
         options={Array.from(WEEKLY_SESSIONS_OPTIONS)}
         onChange={(option) => {
@@ -229,6 +230,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
           markTouched({ weeklySessions: true })
         }}
         success={successMessages.weeklySessions}
+        variant="boxed"
       />
 
       <ToggleField

--- a/src/components/account/fields/BirthDateField.tsx
+++ b/src/components/account/fields/BirthDateField.tsx
@@ -65,9 +65,9 @@ export default function BirthDateField({
     setTouched({ birthDay: true, birthMonth: true, birthYear: true })
   }
 
-  const handleOpenDay = useCallback((open: boolean) => {}, [])
-  const handleOpenMonth = useCallback((open: boolean) => {}, [])
-  const handleOpenYear = useCallback((open: boolean) => {}, [])
+  const handleOpenDay = useCallback(() => {}, [])
+  const handleOpenMonth = useCallback(() => {}, [])
+  const handleOpenYear = useCallback(() => {}, [])
 
   return (
     <div className="w-[368px]">

--- a/src/components/account/fields/DropdownField.tsx
+++ b/src/components/account/fields/DropdownField.tsx
@@ -29,7 +29,7 @@ export default function DropdownField({
   width = 'w-full',
 }: Props) {
   const hasSelection = selected !== ''
-  const showSuccess = !!success
+  const showSuccess = !!success && touched
 
   const buttonClassName = `
     ${width} h-[45px] rounded-[5px] px-[15px]

--- a/src/components/account/fields/ToggleField.tsx
+++ b/src/components/account/fields/ToggleField.tsx
@@ -27,7 +27,7 @@ export default function ToggleField({
   variant = 'segmented',
   itemClassName = '',
 }: Props) {
-  const showSuccess = !!success
+  const showSuccess = !!success && touched
 
   return (
     <div className="w-[368px] flex flex-col text-left">


### PR DESCRIPTION
## Summary
- switch the experience and weekly session toggles to the boxed layout used in the new design
- update the weekly sessions label copy to “Nombre de séances par semaine”
- ensure dropdown and toggle success states respect user interaction and clean up unused callbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d953a50e20832e8a5be2723dfd7700