### PR TITLE
feat: apply unified CTA styling

### DIFF
--- a/src/app/admin/create-offer/page.tsx
+++ b/src/app/admin/create-offer/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabaseClient";
 import ImageUploader from "@/app/admin/components/ImageUploader";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import AdminMultiSelectDropdown from "@/components/AdminMultiSelectDropdown";
+import CTAButton from "@/components/CTAButton";
 
 const days = Array.from({ length: 31 }, (_, i) => (i + 1).toString().padStart(2, "0"));
 const months = [
@@ -553,12 +554,9 @@ export default function CreateOfferPage() {
 
             {/* Bouton */}
             <div className="md:col-span-2 mt-6 flex justify-center">
-              <button
-                onClick={handleSave}
-                className="inline-flex items-center justify-center gap-1 px-4 h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300"
-              >
+              <CTAButton onClick={handleSave}>
                 {offerId ? "Mettre à jour" : "Créer l’offre"}
-              </button>
+              </CTAButton>
             </div>
           </div>
         )}

--- a/src/app/admin/create-program/page.tsx
+++ b/src/app/admin/create-program/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
 import ImageUploader from "@/app/admin/components/ImageUploader";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
+import CTAButton from "@/components/CTAButton";
 
 type Program = {
   id?: number;
@@ -421,17 +422,14 @@ export default function CreateProgramPage() {
             </div> 
           </div>
           <div className="mt-10 flex flex-col items-center">
-            <button
+            <CTAButton
               onClick={handleSave}
               disabled={!isFormValid}
-              className={`inline-flex items-center justify-center gap-1 px-4 h-[44px] rounded-full transition-all duration-300 group font-semibold text-white ${
-                isFormValid
-                  ? "bg-[#7069FA] hover:bg-[#6660E4]"
-                  : "bg-[#C8C8E5] cursor-not-allowed"
-              }`}
+              variant={isFormValid ? "active" : "inactive"}
+              className="font-semibold"
             >
               {programId ? "Mettre à jour" : "Créer la carte"}
-            </button>
+            </CTAButton>
           </div>
         </>
       )}

--- a/src/app/admin/offer-shop/Form.tsx
+++ b/src/app/admin/offer-shop/Form.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import CTAButton from "@/components/CTAButton";
 
 type Program = {
   id?: number;
@@ -102,12 +103,9 @@ export default function ProgramStoreForm({
         />
 
         <div className="flex space-x-2 mt-2">
-          <button
-            type="submit"
-            className="bg-[#7069FA] text-white px-3 py-1 rounded hover:bg-[#5A52D4] transition"
-          >
+          <CTAButton type="submit" className="px-3">
             Enregistrer
-          </button>
+          </CTAButton>
           {program && (
             <button
               type="button"

--- a/src/app/admin/program-store/Form.tsx
+++ b/src/app/admin/program-store/Form.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import CTAButton from "@/components/CTAButton";
 
 type Program = {
   id?: number;
@@ -102,12 +103,9 @@ export default function ProgramStoreForm({
         />
 
         <div className="flex space-x-2 mt-2">
-          <button
-            type="submit"
-            className="bg-[#7069FA] text-white px-3 py-1 rounded hover:bg-[#5A52D4] transition"
-          >
+          <CTAButton type="submit" className="px-3">
             Enregistrer
-          </button>
+          </CTAButton>
           {program && (
             <button
               type="button"

--- a/src/app/admin/slider/page.tsx
+++ b/src/app/admin/slider/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import ImageUploader from "@/app/admin/components/ImageUploader";
+import CTAButton from "@/components/CTAButton";
 
 const sliderTypeOptions = [
   { value: "none", label: "Aucun slider" },
@@ -250,16 +251,9 @@ export default function AdminSliderPage() {
         )}
 
         <div className="mt-10 flex justify-center">
-          <button
-            onClick={handleSave}
-            disabled={loading}
-            className="inline-flex items-center justify-center gap-2 px-4 min-w-[120px] h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300"
-          >
-            {loading && (
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-            )}
+          <CTAButton onClick={handleSave} disabled={loading} loading={loading}>
             Enregistrer
-          </button>
+          </CTAButton>
         </div>
       </div>
     </main>

--- a/src/app/tarifs/page.tsx
+++ b/src/app/tarifs/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import CTAButton from "@/components/CTAButton";
 
 export default function TarifsPage() {
   return (
@@ -90,20 +91,19 @@ export default function TarifsPage() {
 
   {/* Bouton */}
   <div className="mt-10 flex flex-col items-center">
-    <Link
-      href="/inscription"
-      className="inline-flex items-center justify-center gap-1 w-[214px] h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300 group"
-    >
-      Tester gratuitement
-      <div className="relative w-[25px] h-[25px]">
-        <Image
-          src="/icons/arrow.svg"
-          alt="Flèche blanche"
-          fill
-          className="object-contain"
-        />
-      </div>
-    </Link>
+    <CTAButton href="/inscription" className="font-semibold">
+      <span className="inline-flex items-center gap-1">
+        Tester gratuitement
+        <div className="relative w-[25px] h-[25px]">
+          <Image
+            src="/icons/arrow.svg"
+            alt="Flèche blanche"
+            fill
+            className="object-contain"
+          />
+        </div>
+      </span>
+    </CTAButton>
     <div className="flex items-center justify-center gap-2 text-[#5D6494] text-[14px] font-semibold mt-2">
       <span className="relative flex items-center justify-center w-2 h-2">
         <span className="absolute w-full h-full rounded-full bg-[#00D591] opacity-50 animate-ping"></span>

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import clsx from "clsx";
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  MouseEvent,
+  ReactNode,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+type CTAElement = HTMLButtonElement | HTMLAnchorElement;
+
+type BaseProps = {
+  children: ReactNode;
+  href?: string;
+  variant?: "active" | "inactive";
+  loading?: boolean;
+  loadingText?: string;
+  keepWidthWhileLoading?: boolean;
+  onClick?: (event: MouseEvent<CTAElement>) => void | Promise<void>;
+};
+
+type CTAButtonProps = BaseProps &
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "onClick" | "href">;
+
+const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
+  (
+    {
+      children,
+      className,
+      disabled,
+      href,
+      loading,
+      loadingText = "En cours...",
+      keepWidthWhileLoading = true,
+      onClick,
+      type = "button",
+      variant = "active",
+      target,
+      rel,
+      style,
+      ...rest
+    },
+    ref
+  ) => {
+    const router = useRouter();
+    const elementRef = useRef<CTAElement>(null);
+    useImperativeHandle(ref, () => elementRef.current as CTAElement);
+
+    const isControlled = loading !== undefined;
+    const [internalLoading, setInternalLoading] = useState(false);
+    const [storedWidth, setStoredWidth] = useState<number>();
+    const effectiveLoading = loading ?? internalLoading;
+
+    useEffect(() => {
+      if (!keepWidthWhileLoading) return;
+      const element = elementRef.current;
+      if (effectiveLoading) {
+        if (element) {
+          const currentWidth = element.getBoundingClientRect().width;
+          setStoredWidth(currentWidth);
+        }
+      } else if (storedWidth !== undefined) {
+        setStoredWidth(undefined);
+      }
+    }, [effectiveLoading, keepWidthWhileLoading, storedWidth]);
+
+    const handleAsyncResult = useCallback(
+      async (result: void | Promise<void>, event: MouseEvent<CTAElement>) => {
+        const shouldNavigate =
+          Boolean(href) &&
+          !event.defaultPrevented &&
+          (!target || target === "_self");
+
+        if (result instanceof Promise) {
+          if (!isControlled) {
+            setInternalLoading(true);
+          }
+          try {
+            await result;
+          } finally {
+            if ((!shouldNavigate || event.defaultPrevented) && !isControlled) {
+              setInternalLoading(false);
+            }
+          }
+        }
+
+        if (shouldNavigate) {
+          if (!isControlled) {
+            setInternalLoading(true);
+          }
+          router.push(href!);
+        }
+      },
+      [href, isControlled, router, target]
+    );
+
+    const handleClick = useCallback(
+      (event: MouseEvent<CTAElement>) => {
+        if (disabled || effectiveLoading) {
+          event.preventDefault();
+          return;
+        }
+
+        if (keepWidthWhileLoading && elementRef.current) {
+          const currentWidth = elementRef.current.getBoundingClientRect().width;
+          setStoredWidth(currentWidth);
+        }
+
+        const result = onClick?.(event);
+        void handleAsyncResult(result, event);
+      },
+      [disabled, effectiveLoading, handleAsyncResult, keepWidthWhileLoading, onClick]
+    );
+
+    const baseClasses = clsx(
+      "inline-flex items-center justify-center gap-2 h-[44px] px-[15px] rounded-full font-semibold text-[16px] whitespace-nowrap",
+      "transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+      variant === "active" &&
+        "bg-[#7069FA] text-white hover:bg-[#6660E4] focus-visible:ring-[#7069FA]",
+      variant === "inactive" &&
+        "bg-[#F2F1F6] text-[#D7D4DC] hover:bg-[#ECE9F1] focus-visible:ring-[#D7D4DC]",
+      (disabled || effectiveLoading) &&
+        "cursor-not-allowed opacity-100",
+      className
+    );
+
+    const content = effectiveLoading ? (
+      <span className="inline-flex items-center gap-2">
+        <span
+          aria-hidden
+          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+        />
+        <span>{loadingText}</span>
+      </span>
+    ) : (
+      children
+    );
+
+    const computedStyle = storedWidth
+      ? { width: `${storedWidth}px`, ...style }
+      : style;
+
+    if (href) {
+      return (
+        <Link
+          {...rest}
+          href={href}
+          ref={elementRef as React.MutableRefObject<HTMLAnchorElement>}
+          onClick={handleClick as unknown as (event: MouseEvent<HTMLAnchorElement>) => void}
+          className={baseClasses}
+          aria-disabled={disabled || effectiveLoading}
+          tabIndex={disabled || effectiveLoading ? -1 : rest.tabIndex}
+          target={target}
+          rel={rel}
+          style={computedStyle}
+        >
+          {content}
+        </Link>
+      );
+    }
+
+    return (
+      <button
+        {...rest}
+        ref={elementRef as React.MutableRefObject<HTMLButtonElement>}
+        type={type as ButtonHTMLAttributes<HTMLButtonElement>["type"]}
+        disabled={disabled || effectiveLoading}
+        onClick={handleClick as unknown as (event: MouseEvent<HTMLButtonElement>) => void}
+        className={baseClasses}
+        style={computedStyle}
+      >
+        {content}
+      </button>
+    );
+  }
+);
+
+CTAButton.displayName = "CTAButton";
+
+export default CTAButton;

--- a/src/components/DownloadAuthModal.tsx
+++ b/src/components/DownloadAuthModal.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { useState } from "react";
 import ReactDOM from "react-dom";
 import { useRouter } from "next/navigation";
+import CTAButton from "@/components/CTAButton";
 
 interface DownloadAuthModalProps {
   show: boolean;
@@ -54,15 +55,14 @@ export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalPr
           >
             Annuler
           </button>
-          <button
+          <CTAButton
             onClick={() => {
               onClose();
               router.push("/tarifs");
             }}
-            className="inline-flex items-center justify-center gap-1 w-[166px] h-[44px] bg-[#7069FA] hover:bg-[#5E57D8] text-white font-semibold rounded-full transition-all duration-300"
           >
             Créer un compte
-          </button>
+          </CTAButton>
         </div>
       </div>
     </div>,

--- a/src/components/FooterPublic.tsx
+++ b/src/components/FooterPublic.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import CTAButton from "@/components/CTAButton";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFacebookF, faXTwitter, faInstagram, faYoutube } from "@fortawesome/free-brands-svg-icons";
@@ -23,9 +24,12 @@ export default function Footer() {
 
         {/* Right - CTA */}
         <div className="flex flex-col items-start gap-2">
-        <Link href="#" className="w-[214px] h-[44px] bg-[#7069FA] hover:bg-[#5f58e6] text-white text-[16px] font-bold py-3 rounded-full transition flex items-center justify-center gap-2">
-        Tester gratuitement<Image src="/icons/arrow.svg" className="ml-[-5px]" alt="Flèche" width={25} height={25} />
-          </Link>
+        <CTAButton href="#" className="font-bold text-[16px]">
+          <span className="inline-flex items-center gap-2">
+            Tester gratuitement
+            <Image src="/icons/arrow.svg" className="ml-[-5px]" alt="Flèche" width={25} height={25} />
+          </span>
+        </CTAButton>
           {/* Texte centré sous le CTA */}
           <span className="text-[14px] font-semibold text-[#5D6494] flex items-center justify-center w-[204px] gap-2">
             <span className="relative w-[8px] h-[8px]">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useUser } from "@/context/UserContext";
 import { createClientComponentClient } from "@/lib/supabase/client";
+import CTAButton from "@/components/CTAButton";
 
 export default function Header() {
   const pathname = usePathname();
@@ -235,12 +236,7 @@ export default function Header() {
               >
                 Connexion
               </Link>
-              <Link
-                href="/tarifs"
-                className="bg-[#7069FA] hover:bg-[#6660E4] text-white w-[111px] h-[44px] text-[16px] font-semibold flex items-center justify-center rounded-full transition-colors duration-200"
-              >
-                Inscription
-              </Link>
+              <CTAButton href="/tarifs">Inscription</CTAButton>
             </div>
           )}
 

--- a/src/components/LinkModal.tsx
+++ b/src/components/LinkModal.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
+import CTAButton from "@/components/CTAButton";
 
 interface LinkModalProps {
   exercice: string;
@@ -89,22 +90,19 @@ export default function LinkModal({ exercice, initialLink = "", onCancel, onSave
               Annuler
             </button>
           )}
-          <button
+          <CTAButton
             onClick={() => {
               if (link.trim() === "") {
-                // Si vide → supprimer le lien
                 onSave("", exerciceInput);
               } else if (isValidUrl(link)) {
-                // Sinon → enregistrer le lien valide
                 onSave(link, exerciceInput);
               } else {
                 alert("Veuillez entrer un lien valide (http ou https).");
               }
             }}
-            className="inline-flex items-center justify-center gap-1 w-[116px] h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300 group"
           >
             Enregistrer
-          </button>
+          </CTAButton>
         </div>
       </div>
     </div>,

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
+import CTAButton from "@/components/CTAButton";
 
 interface NoteModalProps {
   initialNote: string;
@@ -68,12 +69,9 @@ export default function NoteModal({ initialNote = "", onCancel, onSave }: NoteMo
               Annuler
             </button>
           )}
-          <button
-            onClick={() => onSave(note.trim())}
-            className="inline-flex items-center justify-center gap-1 w-[116px] h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300 group"
-          >
+          <CTAButton onClick={() => onSave(note.trim())}>
             Enregistrer
-          </button>
+          </CTAButton>
         </div>
       </div>
     </div>,

--- a/src/components/OfferCodeModal.tsx
+++ b/src/components/OfferCodeModal.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import Tooltip from "@/components/Tooltip";
+import CTAButton from "@/components/CTAButton";
 
 interface OfferModalProps {
   name: string;
@@ -186,16 +187,23 @@ export default function OfferModal({
           >
             Annuler
           </button>
-          <button
+          <CTAButton
             onClick={() => {
               onConfirm();
               window.open(link, "_blank");
             }}
-            className="inline-flex items-center justify-center gap-2 w-[180px] h-[44px] bg-[#7069FA] hover:bg-[#6660E4] text-white font-semibold rounded-full transition-all duration-300"
           >
-            Aller sur le site
-            <Image src="/icons/arrow.svg" alt="→" width={25} height={25} className="w-[25px] h-[25px]" />
-          </button>
+            <span className="inline-flex items-center gap-2">
+              Aller sur le site
+              <Image
+                src="/icons/arrow.svg"
+                alt="→"
+                width={25}
+                height={25}
+                className="w-[25px] h-[25px]"
+              />
+            </span>
+          </CTAButton>
         </div>
       </div>
     </div>,

--- a/src/components/PremiumOnlyModal.tsx
+++ b/src/components/PremiumOnlyModal.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { useState } from "react";
 import ReactDOM from "react-dom";
 import { useRouter } from "next/navigation";
+import CTAButton from "@/components/CTAButton";
 
 interface DownloadAuthModalProps {
   show: boolean;
@@ -54,15 +55,14 @@ export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalPr
           >
             Annuler
           </button>
-          <button
+          <CTAButton
             onClick={() => {
               onClose();
               router.push("/compte");
             }}
-            className="inline-flex items-center justify-center gap-1 px-4 h-[44px] bg-[#7069FA] hover:bg-[#5E57D8] text-white font-semibold rounded-full transition-all duration-300"
           >
             Débloquer
-          </button>
+          </CTAButton>
         </div>
       </div>
     </div>,

--- a/src/components/account/fields/SubmitButton.tsx
+++ b/src/components/account/fields/SubmitButton.tsx
@@ -1,33 +1,34 @@
-// SubmitButton.tsx
-'use client'
+"use client";
+
+import CTAButton from "@/components/CTAButton";
 
 type Props = {
-  loading: boolean
-  disabled: boolean
-  label?: string
-  onClick?: () => void
-}
+  loading: boolean;
+  disabled: boolean;
+  label?: string;
+  onClick?: () => void;
+};
 
 export default function SubmitButton({
   loading,
   disabled,
-  label = 'Enregistrer mes informations',
+  label = "Enregistrer mes informations",
   onClick,
 }: Props) {
+  const isDisabled = disabled && !loading;
+
   return (
     <div className="w-full flex justify-center mt-3 mb-8">
-      <button
+      <CTAButton
         type="submit"
-        disabled={disabled}
         onClick={onClick}
-        className={`w-[260px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center
-          ${!disabled
-            ? 'bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer'
-            : 'bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed'}
-        `}
+        disabled={isDisabled}
+        loading={loading}
+        variant={isDisabled ? "inactive" : "active"}
+        className="font-bold"
       >
-        {loading ? 'Enregistrement...' : label}
-      </button>
+        {label}
+      </CTAButton>
     </div>
-  )
+  );
 }

--- a/src/components/shop/ShopCard.tsx
+++ b/src/components/shop/ShopCard.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabaseClient";
 import DownloadAuthModal from "@/components/DownloadAuthModal";
 import PremiumOnlyModal from "@/components/PremiumOnlyModal";
 import OfferCodeModal from "@/components/OfferCodeModal";
+import CTAButton from "@/components/CTAButton";
 import { useUser } from "@/context/UserContext";
 
 type Props = {
@@ -297,52 +298,58 @@ export default function ShopCard({ offer }: Props) {
           
         {offer.premium ? (
           !isAuthenticated ? (
-            <button
+            <CTAButton
               onClick={() => setShowModal(true)}
               onMouseEnter={() => setLockedHover(true)}
               onMouseLeave={() => setLockedHover(false)}
-              className="w-auto mt-[20px] mb-[30px] px-6 h-[44px] bg-[#ECE9F1] hover:bg-[#D7D4DC] text-[#D7D4DC] hover:text-[#C2BFC6] rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto transition"
+              variant="inactive"
+              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
             >
-              <Image
-                src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
-                alt=""
-                width={15}
-                height={15}
-              />
-              Profiter de cette offre
-            </button>
+              <span className="inline-flex items-center gap-2">
+                <Image
+                  src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
+                  alt=""
+                  width={15}
+                  height={15}
+                />
+                Profiter de cette offre
+              </span>
+            </CTAButton>
           ) : !isPremiumUser ? (
-            <button
+            <CTAButton
               onClick={() => setShowPremiumModal(true)}
               onMouseEnter={() => setLockedHover(true)}
               onMouseLeave={() => setLockedHover(false)}
-              className="w-auto mt-[20px] mb-[30px] px-6 h-[44px] bg-[#ECE9F1] hover:bg-[#D7D4DC] text-[#D7D4DC] hover:text-[#C2BFC6] rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto transition"
+              variant="inactive"
+              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
             >
-              <Image
-                src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
-                alt=""
-                width={15}
-                height={15}
-              />
-              Profiter de cette offre
-            </button>
+              <span className="inline-flex items-center gap-2">
+                <Image
+                  src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
+                  alt=""
+                  width={15}
+                  height={15}
+                />
+                Profiter de cette offre
+              </span>
+            </CTAButton>
           ) : (
             // Authentifié + premium → bouton actif
-            <button
+            <CTAButton
               onClick={handleClick}
-              className="w-auto mt-[20px] mb-[30px] px-6 h-[44px] bg-[#7069FA] hover:bg-[#5E57D8] text-white rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto transition"
+              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
             >
               Profiter de cette offre
-            </button>
+            </CTAButton>
           )
         ) : (
           // Offres non premium → toujours accessibles
-          <button
+          <CTAButton
             onClick={handleClick}
-            className="w-auto mt-[20px] mb-[30px] px-6 h-[44px] bg-[#7069FA] hover:bg-[#5E57D8] text-white rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto transition"
+            className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
           >
             Profiter de cette offre
-          </button>
+          </CTAButton>
         )}
       </div>
 

--- a/src/components/store/StoreCard.tsx
+++ b/src/components/store/StoreCard.tsx
@@ -5,6 +5,7 @@ import { downloadProgram } from "@/utils/downloadProgram";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import DownloadAuthModal from "@/components/DownloadAuthModal";
+import CTAButton from "@/components/CTAButton";
 
 type Props = {
   program: {
@@ -113,42 +114,34 @@ export default function StoreCard({ program, isAuthenticated }: Props) {
 
         {/* BOUTON TÉLÉCHARGER */}
         {isAuthenticated ? (
-          <button
+          <CTAButton
             onClick={handleDownload}
-            disabled={loading}
-            className={`
-              w-auto px-6 h-[44px]
-              ${loading ? "bg-[#7069FA] cursor-wait" : "bg-[#7069FA] hover:bg-[#5E57D8] cursor-pointer"}
-              text-white rounded-full font-bold text-[16px]
-              transition flex items-center justify-center gap-2 mx-auto
-            `}
+            loading={loading}
+            className="mx-auto font-bold text-[16px]"
           >
-            <div className="flex items-center justify-center h-[20px] gap-2">
-              {loading ? (
-                <span className="animate-spin w-5 h-5 border-2 border-white border-t-transparent rounded-full"></span>
-              ) : (
-                <>
-                  Télécharger
-                  <Image src="/icons/download.svg" alt="" width={20} height={20} />
-                </>
-              )}
-            </div>
-          </button>
+            <span className="inline-flex items-center gap-2">
+              Télécharger
+              <Image src="/icons/download.svg" alt="" width={20} height={20} />
+            </span>
+          </CTAButton>
         ) : (
-          <button
+          <CTAButton
             onClick={() => setShowModal(true)}
             onMouseEnter={() => setLockedHover(true)}
             onMouseLeave={() => setLockedHover(false)}
-            className="w-auto px-6 h-[44px] bg-[#ECE9F1] hover:bg-[#D7D4DC] text-[#D7D4DC] hover:text-[#C2BFC6] rounded-full font-bold text-[16px] flex items-center justify-center gap-2 mx-auto transition"
+            variant="inactive"
+            className="mx-auto font-bold text-[16px]"
           >
-            <Image
-              src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
-              alt=""
-              width={15}
-              height={15}
-            />
-            Télécharger
-          </button>
+            <span className="inline-flex items-center gap-2">
+              <Image
+                src={`/icons/${lockedHover ? "locked_hover" : "locked"}.svg`}
+                alt=""
+                width={15}
+                height={15}
+              />
+              Télécharger
+            </span>
+          </CTAButton>
         )}
 
         {/* LIEN EN SAVOIR PLUS */}


### PR DESCRIPTION
## Summary
- add a reusable CTAButton that centralizes styling, loading feedback, and width preservation for call-to-action elements
- refactor CTA usages across store/shop cards, marketing pages, account and admin forms, and modals to adopt the new component while respecting active/inactive variants

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d95fa17e74832e94647fffbb2445bf