### PR TITLE
Refine inscription UI and improve signup flow

### DIFF
--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -42,20 +42,17 @@ const StepIndicator = ({
   currentStep: number;
 }) => {
   return (
-    <div className="mt-6 flex items-center justify-center gap-2">
+    <div className="mt-6 flex items-center justify-center gap-3">
       {Array.from({ length: totalSteps }).map((_, index) => {
         const step = index + 1;
         const isActive = step === currentStep;
-        const isCompleted = step < currentStep;
         return (
           <span
             key={step}
             aria-hidden
             className={clsx(
-              "h-2.5 w-2.5 rounded-full transition-colors duration-200",
-              isActive && "bg-[#7069FA]",
-              !isActive && !isCompleted && "bg-[#D7D4DC]",
-              isCompleted && "bg-[#00D591]"
+              "h-[9px] w-[9px] rounded-full transition-colors duration-200",
+              isActive ? "bg-[#A1A5FD]" : "bg-[#ECE9F1]"
             )}
           />
         );
@@ -63,13 +60,6 @@ const StepIndicator = ({
     </div>
   );
 };
-
-const PlanBadge = ({ plan }: { plan: PlanType }) => (
-  <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-white/70 px-5 py-2 text-[14px] font-semibold text-[#3A416F] shadow-md">
-    <Image src="/icons/check.svg" alt="Icône validation" width={18} height={18} />
-    <span>{plan === "premium" ? "Formule Premium" : "Formule Starter"}</span>
-  </div>
-);
 
 const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
   const supabase = createClientComponentClient();
@@ -177,8 +167,8 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col items-center w-full">
-      <div className="w-full max-w-[368px]">
+    <form onSubmit={handleSubmit} className="flex w-full max-w-[368px] flex-col items-stretch">
+      <div className="w-full">
         <label htmlFor="prenom" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
           Prénom
         </label>
@@ -208,7 +198,7 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
         </div>
       </div>
 
-      <div className="w-full max-w-[368px]">
+      <div className="w-full">
         <label htmlFor="email" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
           Adresse e-mail
         </label>
@@ -240,7 +230,7 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
         </div>
       </div>
 
-      <div className="w-full max-w-[368px] mb-[10px]">
+      <div className="w-full mb-[10px]">
         <label htmlFor="password" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
           Mot de passe
         </label>
@@ -298,7 +288,7 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
         </div>
       </div>
 
-      <div className="max-w-[368px] mb-[20px] w-full">
+      <div className="mb-[20px] w-full">
         <label className="flex items-start gap-3 cursor-pointer select-none text-[14px] font-semibold text-[#5D6494]">
           <div className="relative w-[15px] h-[15px] shrink-0">
             <input
@@ -347,11 +337,11 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
             height={20}
             className={`w-[20px] h-[20px] transition-colors ${isFormValid ? "invert brightness-0" : ""}`}
           />
-          {loading ? "Création..." : "Créer mon compte"}
+          {loading ? "En cours..." : "Créer mon compte"}
         </button>
       </div>
 
-      <p className="mt-[20px] text-sm font-semibold text-[#5D6494] text-center">
+      <p className="mt-[20px] text-sm font-semibold text-[#5D6494] text-center self-center">
         Déjà inscrit ?{" "}
         <Link href="/connexion" className="text-[#7069FA] hover:text-[#6660E4]">
           Connectez-vous
@@ -826,12 +816,11 @@ const InscriptionPage = () => {
 
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[60px]">
-      <div className="w-full max-w-3xl flex flex-col items-center text-center">
-        <PlanBadge plan={plan} />
+      <div className="w-full max-w-3xl flex flex-col items-center">
         {activeStep && (
           <>
-            <h1 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{activeStep.title}</h1>
-            <p className="mt-2 text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
+            <h1 className="text-center text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{activeStep.title}</h1>
+            <p className="mt-2 text-center text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
               {activeStep.subtitle}
             </p>
           </>

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -25,6 +25,7 @@ type BaseProps = {
   loading?: boolean;
   loadingText?: string;
   keepWidthWhileLoading?: boolean;
+  disableAutoLoading?: boolean;
   onClick?: (event: MouseEvent<CTAElement>) => void | Promise<void>;
 };
 
@@ -42,6 +43,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
       loading,
       loadingText = "En cours...",
       keepWidthWhileLoading = true,
+      disableAutoLoading = false,
       onClick,
       type = "button",
       variant = "active",
@@ -82,26 +84,30 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
           (!target || target === "_self");
 
         if (result instanceof Promise) {
-          if (!isControlled) {
+          if (!isControlled && !disableAutoLoading) {
             setInternalLoading(true);
           }
           try {
             await result;
           } finally {
-            if ((!shouldNavigate || event.defaultPrevented) && !isControlled) {
+            if (
+              (!shouldNavigate || event.defaultPrevented) &&
+              !isControlled &&
+              !disableAutoLoading
+            ) {
               setInternalLoading(false);
             }
           }
         }
 
         if (shouldNavigate) {
-          if (!isControlled) {
+          if (!isControlled && !disableAutoLoading) {
             setInternalLoading(true);
           }
           router.push(href!);
         }
       },
-      [href, isControlled, router, target]
+      [disableAutoLoading, href, isControlled, router, target]
     );
 
     const handleClick = useCallback(
@@ -111,7 +117,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
           return;
         }
 
-        if (keepWidthWhileLoading && elementRef.current) {
+        if (!disableAutoLoading && keepWidthWhileLoading && elementRef.current) {
           const currentWidth = elementRef.current.getBoundingClientRect().width;
           setStoredWidth(currentWidth);
         }
@@ -119,7 +125,14 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
         const result = onClick?.(event);
         void handleAsyncResult(result, event);
       },
-      [disabled, effectiveLoading, handleAsyncResult, keepWidthWhileLoading, onClick]
+      [
+        disableAutoLoading,
+        disabled,
+        effectiveLoading,
+        handleAsyncResult,
+        keepWidthWhileLoading,
+        onClick,
+      ]
     );
 
     const baseClasses = clsx(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -236,7 +236,9 @@ export default function Header() {
               >
                 Connexion
               </Link>
-              <CTAButton href="/tarifs">Inscription</CTAButton>
+              <CTAButton href="/tarifs" disableAutoLoading>
+                Inscription
+              </CTAButton>
             </div>
           )}
 

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -2,7 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
 export function createClient() {
-  const cookieStore = cookies() as unknown as ReadonlyMap<string, { value: string }>;
+  const cookieStore = cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -12,8 +12,19 @@ export function createClient() {
         get(name: string) {
           return cookieStore.get(name)?.value;
         },
-        set() {},
-        remove() {},
+        set(
+          name: string,
+          value: string,
+          options?: Parameters<typeof cookieStore.set>[2]
+        ) {
+          cookieStore.set(name, value, options);
+        },
+        remove(
+          name: string,
+          options?: Parameters<typeof cookieStore.delete>[1]
+        ) {
+          cookieStore.delete(name, options);
+        },
       },
     }
   );


### PR DESCRIPTION
## Summary
- simplify the inscription header by removing the plan badge and centre-align only the headings
- update the step indicator and account creation form to align with the shop slider styling and button copy requirements
- add an option to prevent CTA buttons from entering the loading state and use it for the header signup link
- allow the Supabase server client to set cookies so the signup API no longer fails with a 400 error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d970e42dcc832ead51295eccf0e07a