### PR TITLE
Fix Supabase server client to await cookies

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -3,7 +3,7 @@ import { createAdminClient, createClient } from "@/lib/supabase/server";
 
 export async function POST(req: NextRequest) {
   try {
-    const supabase = createClient();
+    const supabase = await createClient();
     const body = await req.json();
 
     const { email, password, name, plan } = body;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -2,8 +2,8 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export function createClient() {
-  const cookieStore = cookies();
+export async function createClient() {
+  const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- await the Next.js cookies API when instantiating the Supabase server client
- update the signup route to await the async client helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da23028b1c832ebdf7b6423f79f323