### PR TITLE
Support alternative Supabase service env vars

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,9 @@
+# Public credentials
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Server-only credentials
+SUPABASE_SERVICE_ROLE_KEY=
+# Alternate names supported if you already use them:
+# SUPABASE_SERVICE_ROLE=
+# SUPABASE_SERVICE_KEY=

--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, configure your environment variables:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Then update the resulting file with your Supabase project credentials. The
+server-side API routes expect the following variables to be present:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SERVICE_ROLE` / `SUPABASE_SERVICE_KEY`)
+
+Once configured, run the development server:
 
 ```bash
 npm run dev

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -33,7 +33,10 @@ export async function createClient() {
 
 export function createAdminClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const serviceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_SERVICE_ROLE ??
+    process.env.SUPABASE_SERVICE_KEY;
 
   if (!url || !serviceKey) {
     throw new Error("Supabase service credentials are not configured.");


### PR DESCRIPTION
## Summary
- allow the Supabase admin client to read multiple service role environment variable names
- document the required Supabase environment variables for local setup
- add an example .env.local file with the expected keys

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da24223fd8832ea0ed5e730d4141d1