### PR TITLE
feat: add delete account flow in preferences

### DIFF
--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+
+import { createAdminClient, createClient } from '@/lib/supabase/server'
+
+export async function POST() {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError) {
+      console.error('[delete-account] unable to retrieve user', userError)
+      return NextResponse.json({ error: 'user-fetch-failed' }, { status: 500 })
+    }
+
+    if (!user) {
+      return NextResponse.json({ error: 'not-authenticated' }, { status: 401 })
+    }
+
+    const adminClient = createAdminClient()
+    const userId = user.id
+
+    const tables: Array<'user_subscriptions' | 'training_rows' | 'trainings' | 'programs'> = [
+      'user_subscriptions',
+      'training_rows',
+      'trainings',
+      'programs',
+    ]
+
+    for (const table of tables) {
+      const { error } = await adminClient.from(table).delete().eq('user_id', userId)
+      if (error) {
+        console.error(`[delete-account] failed to clean table ${table}`, error)
+        throw new Error(`cleanup-${table}`)
+      }
+    }
+
+    const { error: signOutError } = await supabase.auth.signOut()
+    if (signOutError) {
+      console.error('[delete-account] sign out failed', signOutError)
+    }
+
+    const { error: deleteUserError } = await adminClient.auth.admin.deleteUser(userId)
+    if (deleteUserError) {
+      console.error('[delete-account] failed to delete auth user', deleteUserError)
+      throw new Error('delete-user')
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error: unknown) {
+    console.error('[delete-account] unexpected error', error)
+    const message = error instanceof Error ? error.message : undefined
+    return NextResponse.json(
+      { error: message || 'delete-account-failed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/DeleteAccountButtonWithModal.tsx
+++ b/src/components/DeleteAccountButtonWithModal.tsx
@@ -1,0 +1,162 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import Spinner from '@/components/ui/Spinner'
+
+type Props = {
+  /** Action custom si vous ne voulez pas utiliser /api/delete-account */
+  onConfirm?: () => Promise<void>
+}
+
+export default function DeleteAccountButtonWithModal({ onConfirm }: Props) {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hoveredClose, setHoveredClose] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const handleConfirm = async () => {
+    if (loading) return
+
+    setError(null)
+    setLoading(true)
+
+    try {
+      if (onConfirm) {
+        await onConfirm()
+      } else {
+        const res = await fetch('/api/delete-account', { method: 'POST' })
+        if (!res.ok) {
+          let details: string | undefined
+          try {
+            const data = await res.json()
+            details = data?.details || data?.error
+            console.error('[delete-account] server details:', data)
+          } catch {}
+
+          throw new Error(details || 'delete-failed')
+        }
+      }
+
+      setOpen(false)
+      window.location.href = '/'
+    } catch (err: unknown) {
+      console.error(err)
+      const message = err instanceof Error ? err.message : null
+      setError(message || 'Une erreur est survenue. Merci de réessayer.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-[50px] mx-auto block text-[14px] font-semibold text-[#EF4F4E] transition-colors hover:text-[#BA2524]"
+      >
+        Supprimer mon compte
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-[#2E3142]/60"
+            onClick={() => !loading && setOpen(false)}
+            aria-hidden="true"
+          />
+
+          <div className="relative z-10 w-[564px] max-w-[92vw] rounded-[5px] bg-white p-8 shadow-lg">
+            <button
+              onClick={() => !loading && setOpen(false)}
+              onMouseEnter={() => setHoveredClose(true)}
+              onMouseLeave={() => setHoveredClose(false)}
+              className={`absolute right-4 top-4 h-6 w-6 ${loading ? 'pointer-events-none' : ''}`}
+              aria-label="Fermer"
+              aria-disabled={loading}
+            >
+              <Image
+                src={hoveredClose ? '/icons/close_hover.svg' : '/icons/close.svg'}
+                alt="Fermer"
+                width={24}
+                height={24}
+                className="h-full w-full"
+              />
+            </button>
+
+            <h2 className="mb-6 text-center text-[22px] font-bold text-[#3A416F]">
+              Supprimer votre compte
+            </h2>
+
+            <div className="mb-6 rounded-br-[5px] rounded-tr-[5px] border-l-[3px] border-[#EF4F4E] bg-[#FFE3E3] pl-4 py-3 text-left">
+              <div className="text-[12px] font-bold text-[#BA2524]">Attention</div>
+              <div className="text-[12px] font-semibold text-[#EF4F4E]">
+                La suppression de votre compte est définitive.
+              </div>
+            </div>
+
+            <p className="mb-4 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+              En cliquant sur <span className="text-[#3A416F]">« Confirmer »</span> votre compte ainsi que l’ensemble des données qui lui sont associées seront{' '}
+              <span className="text-[#3A416F]">définitivement supprimées</span> de la plateforme.
+            </p>
+            <p className="mb-6 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+              Si ce n’est pas ce que vous souhaitez faire, vous trouverez peut-être la solution à votre besoin dans la partie{' '}
+              <Link href="/aide" className="underline text-[#3A416F]">
+                Aide
+              </Link>{' '}
+              du site.
+            </p>
+
+            {error && (
+              <p className="mb-4 text-left text-[14px] font-semibold text-[#BA2524]">{error}</p>
+            )}
+
+            <div className="flex justify-center gap-4">
+              <button
+                type="button"
+                onClick={() => !loading && setOpen(false)}
+                aria-disabled={loading}
+                className={`px-4 py-2 font-semibold text-[#5D6494] hover:text-[#3A416F] ${loading ? 'pointer-events-none' : ''}`}
+              >
+                Annuler
+              </button>
+
+              <button
+                type="button"
+                onClick={!loading ? handleConfirm : undefined}
+                aria-busy={loading}
+                aria-disabled={loading}
+                className={`
+                  inline-flex min-w-[136px] h-[44px] items-center justify-center gap-2
+                  rounded-full font-semibold text-white transition-colors
+                  bg-[#EF4F4E] ${loading ? 'opacity-100 pointer-events-none cursor-wait' : 'hover:bg-[#BA2524]'}
+                `}
+              >
+                {loading ? (
+                  <>
+                    <Spinner size="md" className="text-white" ariaLabel="Suppression en cours" />
+                    En cours...
+                  </>
+                ) : (
+                  'Confirmer'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/account/sections/PreferencesSection.tsx
+++ b/src/components/account/sections/PreferencesSection.tsx
@@ -1,12 +1,18 @@
 "use client"
 
+import DeleteAccountButtonWithModal from "@/components/DeleteAccountButtonWithModal"
 import AccountAccordionSection from "../AccountAccordionSection"
 
 export default function PreferencesSection() {
   return (
     <AccountAccordionSection value="mes-preferences" title="Mes préférences">
-      {/* Contenu à venir */}
-      <div></div>
+      <div className="flex flex-col items-center gap-6 text-center">
+        <p className="text-[14px] font-semibold leading-normal text-[#5D6494]">
+          Bientôt, vous pourrez personnaliser vos préférences depuis cette rubrique.
+        </p>
+
+        <DeleteAccountButtonWithModal />
+      </div>
     </AccountAccordionSection>
   )
 }

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx'
+
+type SpinnerSize = 'sm' | 'md' | 'lg'
+
+type SpinnerProps = {
+  size?: SpinnerSize
+  className?: string
+  ariaLabel?: string
+}
+
+const sizeMap: Record<SpinnerSize, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+}
+
+export default function Spinner({ size = 'sm', className, ariaLabel }: SpinnerProps) {
+  return (
+    <svg
+      className={clsx('animate-spin text-current', sizeMap[size], className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      role="status"
+      aria-label={ariaLabel}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add a delete account modal button to the "Mes préférences" section
- create an API endpoint that purges Supabase data and deletes the authenticated user
- introduce a reusable spinner component for loading indicators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da2a2c413c832e9eb50b8dbcee1e3d