### PR TITLE
feat: add reusable confirmation modals

### DIFF
--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -21,7 +21,7 @@ type CTAElement = HTMLButtonElement | HTMLAnchorElement;
 type BaseProps = {
   children: ReactNode;
   href?: string;
-  variant?: "active" | "inactive";
+  variant?: "active" | "inactive" | "danger";
   loading?: boolean;
   loadingText?: string;
   keepWidthWhileLoading?: boolean;
@@ -142,6 +142,8 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
         "bg-[#7069FA] text-white hover:bg-[#6660E4] focus-visible:ring-[#7069FA]",
       variant === "inactive" &&
         "bg-[#F2F1F6] text-[#D7D4DC] hover:bg-[#ECE9F1] focus-visible:ring-[#D7D4DC]",
+      variant === "danger" &&
+        "bg-[#EF4F4E] text-white hover:bg-[#BA2524] focus-visible:ring-[#EF4F4E]",
       (disabled || effectiveLoading) &&
         "cursor-not-allowed opacity-100",
       className

--- a/src/components/DeleteAccountButtonWithModal.tsx
+++ b/src/components/DeleteAccountButtonWithModal.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
-import Image from 'next/image'
 import clsx from 'clsx'
-import Spinner from '@/components/ui/Spinner'
+import ConfirmationModal from '@/components/ui/ConfirmationModal'
 
 type Props = {
   /** Action custom si vous ne voulez pas utiliser /api/delete-account */
@@ -20,18 +19,6 @@ export default function DeleteAccountButtonWithModal({ onConfirm, triggerClassNa
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [hoveredClose, setHoveredClose] = useState(false)
-
-  useEffect(() => {
-    if (!open) return
-
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open])
 
   const handleConfirm = async () => {
     if (loading) return
@@ -71,98 +58,42 @@ export default function DeleteAccountButtonWithModal({ onConfirm, triggerClassNa
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="mt-[50px] mx-auto block text-[14px] font-semibold text-[#EF4F4E] transition-colors hover:text-[#BA2524]"
+        className={clsx('mt-[50px]', triggerBaseClasses, triggerClassName)}
       >
         Supprimer mon compte
       </button>
 
-      {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div
-            className="absolute inset-0 bg-[#2E3142]/60"
-            onClick={() => !loading && setOpen(false)}
-            aria-hidden="true"
-          />
+      <ConfirmationModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={handleConfirm}
+        title="Supprimer votre compte"
+        variant="warning"
+        messageTitle="Attention"
+        messageDescription="La suppression de votre compte est définitive."
+        confirmLabel="Confirmer"
+        confirmButtonProps={{
+          loading,
+          loadingText: 'En cours...',
+          keepWidthWhileLoading: true,
+        }}
+      >
+        <p className="mb-4 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+          En cliquant sur <span className="text-[#3A416F]">« Confirmer »</span> votre compte ainsi que l’ensemble des données qui lui
+          sont associées seront <span className="text-[#3A416F]">définitivement supprimées</span> de la plateforme.
+        </p>
+        <p className="text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+          Si ce n’est pas ce que vous souhaitez faire, vous trouverez peut-être la solution à votre besoin dans la partie{' '}
+          <Link href="/aide" className="underline text-[#3A416F]">
+            Aide
+          </Link>{' '}
+          du site.
+        </p>
 
-          <div className="relative z-10 w-[564px] max-w-[92vw] rounded-[5px] bg-white p-8 shadow-lg">
-            <button
-              onClick={() => !loading && setOpen(false)}
-              onMouseEnter={() => setHoveredClose(true)}
-              onMouseLeave={() => setHoveredClose(false)}
-              className={`absolute right-4 top-4 h-6 w-6 ${loading ? 'pointer-events-none' : ''}`}
-              aria-label="Fermer"
-              aria-disabled={loading}
-            >
-              <Image
-                src={hoveredClose ? '/icons/close_hover.svg' : '/icons/close.svg'}
-                alt="Fermer"
-                width={24}
-                height={24}
-                className="h-full w-full"
-              />
-            </button>
-
-            <h2 className="mb-6 text-center text-[22px] font-bold text-[#3A416F]">
-              Supprimer votre compte
-            </h2>
-
-            <div className="mb-6 rounded-br-[5px] rounded-tr-[5px] border-l-[3px] border-[#EF4F4E] bg-[#FFE3E3] pl-4 py-3 text-left">
-              <div className="text-[12px] font-bold text-[#BA2524]">Attention</div>
-              <div className="text-[12px] font-semibold text-[#EF4F4E]">
-                La suppression de votre compte est définitive.
-              </div>
-            </div>
-
-            <p className="mb-4 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
-              En cliquant sur <span className="text-[#3A416F]">« Confirmer »</span> votre compte ainsi que l’ensemble des données qui lui sont associées seront{' '}
-              <span className="text-[#3A416F]">définitivement supprimées</span> de la plateforme.
-            </p>
-            <p className="mb-6 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
-              Si ce n’est pas ce que vous souhaitez faire, vous trouverez peut-être la solution à votre besoin dans la partie{' '}
-              <Link href="/aide" className="underline text-[#3A416F]">
-                Aide
-              </Link>{' '}
-              du site.
-            </p>
-
-            {error && (
-              <p className="mb-4 text-left text-[14px] font-semibold text-[#BA2524]">{error}</p>
-            )}
-
-            <div className="flex justify-center gap-4">
-              <button
-                type="button"
-                onClick={() => !loading && setOpen(false)}
-                aria-disabled={loading}
-                className={`px-4 py-2 font-semibold text-[#5D6494] hover:text-[#3A416F] ${loading ? 'pointer-events-none' : ''}`}
-              >
-                Annuler
-              </button>
-
-              <button
-                type="button"
-                onClick={!loading ? handleConfirm : undefined}
-                aria-busy={loading}
-                aria-disabled={loading}
-                className={`
-                  inline-flex min-w-[136px] h-[44px] items-center justify-center gap-2
-                  rounded-full font-semibold text-white transition-colors
-                  bg-[#EF4F4E] ${loading ? 'opacity-100 pointer-events-none cursor-wait' : 'hover:bg-[#BA2524]'}
-                `}
-              >
-                {loading ? (
-                  <>
-                    <Spinner size="md" className="text-white" ariaLabel="Suppression en cours" />
-                    En cours...
-                  </>
-                ) : (
-                  'Confirmer'
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+        {error && (
+          <p className="mt-6 text-left text-[14px] font-semibold text-[#BA2524]">{error}</p>
+        )}
+      </ConfirmationModal>
     </>
   )
 }

--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import clsx from "clsx"
+import { ButtonHTMLAttributes, ComponentPropsWithoutRef, ReactNode } from "react"
+import CTAButton from "@/components/CTAButton"
+import Modal from "@/components/ui/Modal"
+import ModalMessage from "@/components/ui/ModalMessage"
+
+type CTAButtonProps = ComponentPropsWithoutRef<typeof CTAButton>
+
+interface ConfirmationModalProps {
+  open: boolean
+  title: string
+  variant: "warning" | "info"
+  messageTitle: ReactNode
+  messageDescription: ReactNode
+  onConfirm: () => void | Promise<void>
+  confirmLabel: ReactNode
+  onClose: () => void
+  cancelLabel?: ReactNode
+  onCancel?: () => void
+  children?: ReactNode
+  confirmButtonProps?: Omit<CTAButtonProps, "children" | "onClick" | "variant"> & {
+    className?: string
+  }
+  cancelButtonProps?: Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "onClick"> & {
+    className?: string
+  }
+  actionsClassName?: string
+  messageClassName?: string
+}
+
+export default function ConfirmationModal({
+  open,
+  title,
+  variant,
+  messageTitle,
+  messageDescription,
+  onConfirm,
+  confirmLabel,
+  onClose,
+  cancelLabel = "Annuler",
+  onCancel,
+  children,
+  confirmButtonProps,
+  cancelButtonProps,
+  actionsClassName,
+  messageClassName,
+}: ConfirmationModalProps) {
+  const {
+    className: confirmClassName,
+    keepWidthWhileLoading = true,
+    loadingText = "En cours...",
+    loading: confirmLoading = false,
+    disabled: confirmDisabled,
+    ...restConfirmButtonProps
+  } = confirmButtonProps ?? {}
+
+  const {
+    className: cancelClassName,
+    disabled: cancelDisabledFromProps,
+    ...restCancelButtonProps
+  } = cancelButtonProps ?? {}
+
+  const isLoading = Boolean(confirmLoading)
+  const confirmButtonDisabled = Boolean(confirmDisabled)
+  const cancelDisabled = isLoading || Boolean(cancelDisabledFromProps)
+
+  const handleCancel = () => {
+    if (cancelDisabled) return
+    onCancel?.()
+    onClose()
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={title}
+      closeDisabled={isLoading}
+      footer={
+        <div className={clsx("flex justify-center gap-4", actionsClassName)}>
+          <button
+            type="button"
+            onClick={handleCancel}
+            aria-disabled={cancelDisabled}
+            className={clsx(
+              "px-4 py-2 font-semibold text-[#5D6494] hover:text-[#3A416F]",
+              cancelDisabled && "pointer-events-none",
+              cancelClassName
+            )}
+            {...restCancelButtonProps}
+          >
+            {cancelLabel}
+          </button>
+
+          <CTAButton
+            type="button"
+            variant={variant === "warning" ? "danger" : "active"}
+            onClick={onConfirm}
+            loading={confirmLoading}
+            loadingText={loadingText}
+            keepWidthWhileLoading={keepWidthWhileLoading}
+            disabled={confirmButtonDisabled}
+            className={clsx("min-w-[136px]", confirmClassName)}
+            {...restConfirmButtonProps}
+          >
+            {confirmLabel}
+          </CTAButton>
+        </div>
+      }
+    >
+      <ModalMessage
+        variant={variant}
+        title={messageTitle}
+        description={messageDescription}
+        className={clsx("mb-6", messageClassName)}
+      />
+      {children}
+    </Modal>
+  )
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import Image from "next/image"
+import { createPortal } from "react-dom"
+import clsx from "clsx"
+import {
+  PropsWithChildren,
+  ReactNode,
+  useEffect,
+  useId,
+  useState,
+} from "react"
+
+type ModalProps = PropsWithChildren<{
+  open: boolean
+  title: string
+  onClose?: () => void
+  closeDisabled?: boolean
+  footer?: ReactNode
+  closeLabel?: string
+  className?: string
+  contentClassName?: string
+  titleClassName?: string
+  showCloseButton?: boolean
+}>
+
+export default function Modal({
+  open,
+  title,
+  onClose,
+  closeDisabled = false,
+  footer,
+  closeLabel = "Fermer",
+  className,
+  contentClassName,
+  titleClassName,
+  showCloseButton = true,
+  children,
+}: ModalProps) {
+  const [mounted, setMounted] = useState(false)
+  const [closeHovered, setCloseHovered] = useState(false)
+  const labelId = useId()
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!open || !onClose || closeDisabled) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [open, onClose, closeDisabled])
+
+  if (!mounted || !open) {
+    return null
+  }
+
+  const handleOverlayClick = () => {
+    if (closeDisabled) return
+    onClose?.()
+  }
+
+  const handleClose = () => {
+    if (closeDisabled) return
+    onClose?.()
+  }
+
+  const closeIcon =
+    closeHovered && !closeDisabled
+      ? "/icons/close_hover.svg"
+      : "/icons/close.svg"
+
+  return createPortal(
+    <div className={clsx("fixed inset-0 z-50 flex items-center justify-center", className)}>
+      <div
+        className="absolute inset-0 bg-[#2E3142]/60"
+        onClick={handleOverlayClick}
+        aria-hidden="true"
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelId}
+        className={clsx(
+          "relative z-10 w-[564px] max-w-[92vw] rounded-[5px] bg-white p-8 shadow-lg",
+          contentClassName
+        )}
+      >
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={handleClose}
+            onMouseEnter={() => setCloseHovered(true)}
+            onMouseLeave={() => setCloseHovered(false)}
+            className={clsx(
+              "absolute right-4 top-4 h-6 w-6 transition-opacity",
+              closeDisabled && "cursor-not-allowed opacity-60"
+            )}
+            aria-label={closeLabel}
+            aria-disabled={closeDisabled}
+            disabled={closeDisabled}
+          >
+            <Image
+              src={closeIcon}
+              alt="Fermer"
+              width={24}
+              height={24}
+              className="h-full w-full"
+            />
+          </button>
+        )}
+
+        <h2
+          id={labelId}
+          className={clsx(
+            "mb-6 text-center text-[22px] font-bold text-[#3A416F]",
+            titleClassName
+          )}
+        >
+          {title}
+        </h2>
+
+        {children}
+
+        {footer && <div className="mt-6">{footer}</div>}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/ui/ModalMessage.tsx
+++ b/src/components/ui/ModalMessage.tsx
@@ -1,0 +1,60 @@
+import clsx from "clsx"
+import { ReactNode } from "react"
+
+type ModalMessageVariant = "warning" | "info"
+
+const VARIANT_STYLES: Record<ModalMessageVariant, {
+  background: string
+  titleColor: string
+  textColor: string
+  barColor: string
+}> = {
+  warning: {
+    background: "#FFE3E3",
+    titleColor: "#BA2524",
+    textColor: "#EF4F4E",
+    barColor: "#EF4F4E",
+  },
+  info: {
+    background: "#F4F5FE",
+    titleColor: "#7069FA",
+    textColor: "#A1A5FD",
+    barColor: "#A1A5FD",
+  },
+}
+
+interface ModalMessageProps {
+  variant: ModalMessageVariant
+  title: ReactNode
+  description: ReactNode
+  className?: string
+}
+
+export default function ModalMessage({
+  variant,
+  title,
+  description,
+  className,
+}: ModalMessageProps) {
+  const styles = VARIANT_STYLES[variant]
+
+  return (
+    <div
+      className={clsx(
+        "rounded-br-[5px] rounded-tr-[5px] border-l-[3px] px-4 py-3 text-left",
+        className
+      )}
+      style={{
+        backgroundColor: styles.background,
+        borderLeftColor: styles.barColor,
+      }}
+    >
+      <div className="text-[12px] font-bold" style={{ color: styles.titleColor }}>
+        {title}
+      </div>
+      <div className="text-[12px] font-semibold" style={{ color: styles.textColor }}>
+        {description}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable modal primitives to share layout, left-bar messaging, and action handling for warning and information dialogs
- extend CTAButton with a red "danger" variant and expose a ConfirmationModal helper component for both modal styles
- refactor the delete-account confirmation flow to consume the new components and keep loader behaviour consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da31e1a49c832ebf92a03808cde9db