### PR TITLE
Protect authenticated routes and concept redirect

### DIFF
--- a/src/app/concept/page.tsx
+++ b/src/app/concept/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ConceptPageRedirect() {
+  redirect("/");
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useUser } from "@supabase/auth-helpers-react";
+import { useUser } from "@/context/UserContext";
 import FooterPublic from "./FooterPublic";
 import FooterLogged from "./FooterLogged";
 
 export default function Footer() {
-  const user = useUser();
+  const { isAuthenticated } = useUser();
 
-  return user ? <FooterLogged /> : <FooterPublic />;
+  return isAuthenticated ? <FooterLogged /> : <FooterPublic />;
 }


### PR DESCRIPTION
## Summary
- redirect the concept route to the homepage via middleware and route handler
- block dashboard, entrainements and compte for unauthenticated visitors in middleware
- align the footer display with the shared user context for consistent authenticated state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da369fad28832e8051ee08c22e47ca