### PR TITLE
Add server-side Supabase session guards to protected layouts

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import AdminHeader from "@/components/AdminHeader";
 import { Quicksand } from "next/font/google";
+import { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabaseServer";
 
 const quicksand = Quicksand({
   subsets: ["latin"],
@@ -14,15 +17,28 @@ export const metadata: Metadata = {
   manifest: "/favicons/admin/manifest.webmanifest",
   icons: {
     icon: "/favicons/admin/favicon-32x32.png",
-    apple: "/favicons/admin/apple-touch-icon.png"
-  }
+    apple: "/favicons/admin/apple-touch-icon.png",
+  },
 };
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/connexion");
+  }
+
+  if (!user.user_metadata?.is_admin) {
+    redirect("/");
+  }
+
   return (
     <div className={quicksand.className}>
       <AdminHeader />

--- a/src/app/compte/layout.tsx
+++ b/src/app/compte/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabaseServer";
+
+export default async function CompteLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/connexion");
+  }
+
+  return children;
+}

--- a/src/app/compte/page.tsx
+++ b/src/app/compte/page.tsx
@@ -20,8 +20,6 @@ export default function ComptePage() {
     }
   }, [])
 
-  if (!user) return null
-
   return (
     <main className="min-h-screen bg-[#FBFCFE] px-4 pt-[140px] pb-[60px]">
       <div className="max-w-[1152px] mx-auto text-center flex flex-col items-center">

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabaseServer";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/connexion");
+  }
+
+  return children;
+}

--- a/src/app/entrainements/layout.tsx
+++ b/src/app/entrainements/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabaseServer";
+
+export default async function EntrainementsLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/connexion");
+  }
+
+  return children;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,34 +1,8 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient } from "@/lib/supabaseServer";
 
 export async function createClient() {
-  const cookieStore = await cookies();
-
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(
-          name: string,
-          value: string,
-          options?: Parameters<typeof cookieStore.set>[2]
-        ) {
-          cookieStore.set(name, value, options);
-        },
-        remove(
-          name: string,
-          options?: Parameters<typeof cookieStore.delete>[1]
-        ) {
-          cookieStore.delete(name, options);
-        },
-      },
-    }
-  );
+  return createServerClient();
 }
 
 export function createAdminClient() {

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,31 @@
+import { createServerClient as createSupabaseServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createServerClient() {
+  const cookieStore = await cookies();
+
+  return createSupabaseServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
+        },
+        set(
+          name: string,
+          value: string,
+          options?: Parameters<typeof cookieStore.set>[2]
+        ) {
+          cookieStore.set(name, value, options);
+        },
+        remove(
+          name: string,
+          options?: Parameters<typeof cookieStore.delete>[1]
+        ) {
+          cookieStore.delete(name, options);
+        },
+      },
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable Supabase server client helper wired to Next.js cookies
- guard dashboard, account, trainings, and admin layouts on the server with Supabase auth redirects
- remove redundant client-side null check now enforced by server redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da444ddc38832ebdff069f09514baa