### PR TITLE
feat: align checkboxes with icon assets

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase/client";
+import { IconCheckbox } from "@/components/ui/IconCheckbox";
 
 export default function ConnexionPage() {
   const [email, setEmail] = useState("");
@@ -126,26 +127,12 @@ export default function ConnexionPage() {
           {/* Checkbox */}
           <div className="max-w-[368px] mb-[20px] w-full">
             <label className="flex items-center gap-2 cursor-pointer text-[14px] font-semibold text-[#5D6494]">
-              <div className="relative w-[15px] h-[15px] shrink-0">
-                <input
-                  type="checkbox"
-                  name="remember"
-                  checked={rememberMe}
-                  onChange={(e) => setRememberMe(e.target.checked)}
-                  className="peer appearance-none w-full h-full border rounded-[3px] transition-colors duration-150 cursor-pointer
-                    border-[#D7D4DC]
-                    hover:border-[#C2BFC6]
-                    checked:border-[#7069FA]
-                    checked:hover:border-[#7069FA]
-                    checked:bg-[#7069FA]"
-                />
-                <svg
-                  viewBox="0 0 24 24"
-                  className="pointer-events-none absolute top-1/2 left-1/2 w-[13px] h-[13px] -translate-x-1/2 -translate-y-1/2 fill-white hidden peer-checked:block"
-                >
-                  <path d="M20.285 6.709a1 1 0 0 0-1.414-1.418l-9.572 9.58-4.16-4.17a1 1 0 1 0-1.414 1.414l5.586 5.586a1 1 0 0 0 1.414 0l9.56-9.592z" />
-                </svg>
-              </div>
+              <IconCheckbox
+                name="remember"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                size={15}
+              />
               Je veux rester connecté.
             </label>
           </div>

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import clsx from "clsx";
 
+import { IconCheckbox } from "@/components/ui/IconCheckbox";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import {
   EXPERIENCE_OPTIONS,
@@ -290,20 +291,12 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
 
       <div className="mb-[20px] w-full">
         <label className="flex items-start gap-3 cursor-pointer select-none text-[14px] font-semibold text-[#5D6494]">
-          <div className="relative w-[15px] h-[15px] shrink-0">
-            <input
-              type="checkbox"
-              checked={accepted}
-              onChange={(event) => setAccepted(event.target.checked)}
-              className="peer appearance-none w-full h-full border rounded-[3px] transition-colors duration-150 border-[#D7D4DC] hover:border-[#C2BFC6] checked:border-[#7069FA] checked:bg-[#7069FA] cursor-pointer"
-            />
-            <svg
-              viewBox="0 0 24 24"
-              className="pointer-events-none absolute top-1/2 left-1/2 w-[13px] h-[13px] -translate-x-1/2 -translate-y-1/2 fill-white hidden peer-checked:block"
-            >
-              <path d="M20.285 6.709a1 1 0 0 0-1.414-1.418l-9.572 9.58-4.16-4.17a1 1 0 1 0-1.414 1.414l5.586 5.586a1 1 0 0 0 1.414 0l9.56-9.592z" />
-            </svg>
-          </div>
+          <IconCheckbox
+            checked={accepted}
+            onChange={(event) => setAccepted(event.target.checked)}
+            size={15}
+            containerClassName="mt-[3px]"
+          />
           <span className="mt-[-3px]">
             J’accepte la{" "}
             <Link href="#" className="text-[#7069FA] hover:text-[#6660E4]">
@@ -474,12 +467,12 @@ const PaymentStep = ({ onComplete }: PaymentStepProps) => {
         </div>
       </div>
 
-      <label className="mt-6 flex items-start gap-3 text-[13px] font-semibold text-[#5D6494]">
-        <input
-          type="checkbox"
+      <label className="mt-6 flex items-start gap-3 text-[13px] font-semibold text-[#5D6494] cursor-pointer">
+        <IconCheckbox
           checked={termsAccepted}
           onChange={(event) => setTermsAccepted(event.target.checked)}
-          className="mt-[3px] h-[16px] w-[16px] cursor-pointer rounded border border-[#D7D4DC] text-[#7069FA] focus:ring-[#7069FA]"
+          size={16}
+          containerClassName="mt-[3px]"
         />
         <span>
           Je confirme que je m’abonne à un service facturé 2,49 €/mois, renouvelé automatiquement à la fin de la période d’essai

--- a/src/components/ui/IconCheckbox.tsx
+++ b/src/components/ui/IconCheckbox.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+export type IconCheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> & {
+  size?: number;
+  containerClassName?: string;
+};
+
+const IconCheckbox = React.forwardRef<HTMLInputElement, IconCheckboxProps>(
+  ({ size = 16, containerClassName, className, ...props }, ref) => {
+    return (
+      <span
+        className={cn("relative inline-flex shrink-0", containerClassName)}
+        style={{ width: size, height: size }}
+      >
+        <input
+          {...props}
+          ref={ref}
+          type="checkbox"
+          className={cn(
+            "peer absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0",
+            className
+          )}
+        />
+        <Image
+          src="/icons/checkbox_unchecked.svg"
+          alt=""
+          width={size}
+          height={size}
+          className="pointer-events-none absolute inset-0 h-full w-full peer-checked:hidden"
+        />
+        <Image
+          src="/icons/checkbox_checked.svg"
+          alt=""
+          width={size}
+          height={size}
+          className="pointer-events-none absolute inset-0 hidden h-full w-full peer-checked:block"
+        />
+      </span>
+    );
+  }
+);
+
+IconCheckbox.displayName = "IconCheckbox";
+
+export { IconCheckbox };


### PR DESCRIPTION
## Summary
- introduce a reusable IconCheckbox component that renders the checked/unchecked SVG assets
- update login and signup flows to use the new icon-based checkbox while preserving sizing
- ensure all user-facing checkboxes are consistent with the desired SVG design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da46556c58832e96f9acefe3a70644