### PR TITLE
Refactor signup flow into dedicated onboarding pages

### DIFF
--- a/src/app/inscription/components/StepIndicator.tsx
+++ b/src/app/inscription/components/StepIndicator.tsx
@@ -1,0 +1,35 @@
+import clsx from "clsx";
+
+export type StepIndicatorProps = {
+  totalSteps: number;
+  currentStep: number;
+  className?: string;
+};
+
+const StepIndicator = ({ totalSteps, currentStep, className }: StepIndicatorProps) => {
+  if (totalSteps <= 1) {
+    return null;
+  }
+
+  return (
+    <div className={clsx("mt-6 flex items-center justify-center gap-2", className)}>
+      {Array.from({ length: totalSteps }).map((_, index) => {
+        const step = index + 1;
+        const isActive = step === currentStep;
+
+        return (
+          <span
+            key={step}
+            aria-hidden
+            className={clsx(
+              "h-[9px] w-[9px] rounded-full transition-colors duration-200",
+              isActive ? "bg-[#A1A5FD]" : "bg-[#ECE9F1]"
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default StepIndicator;

--- a/src/app/inscription/constants.ts
+++ b/src/app/inscription/constants.ts
@@ -1,0 +1,76 @@
+export type PlanType = "starter" | "premium";
+
+export type StepKey = "account" | "payment" | "profile";
+
+export type StepMetadata = {
+  title: string;
+  subtitle: string;
+  currentStep: number;
+  totalSteps: number;
+};
+
+const STEP_DETAILS: Record<StepKey, { title: string; subtitle: string }> = {
+  account: {
+    title: "Création de votre compte",
+    subtitle:
+      "Créez un compte en moins d’une minute pour commencer à utiliser la plateforme Glift.",
+  },
+  payment: {
+    title: "Mode de paiement",
+    subtitle: "Activez votre essai gratuit en renseignant vos informations de paiement.",
+  },
+  profile: {
+    title: "Inscription terminée !",
+    subtitle: "Complétez votre profil pour personnaliser vos entraînements.",
+  },
+};
+
+const STEP_SEQUENCE: Record<PlanType, StepKey[]> = {
+  starter: ["account", "profile"],
+  premium: ["account", "payment", "profile"],
+};
+
+export const parsePlan = (value: string | null): PlanType | null => {
+  if (value === "starter" || value === "premium") {
+    return value;
+  }
+
+  return null;
+};
+
+export const getStepMetadata = (plan: PlanType | null, step: StepKey): StepMetadata | null => {
+  if (!plan) {
+    return null;
+  }
+
+  const sequence = STEP_SEQUENCE[plan];
+  const index = sequence.indexOf(step);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const { title, subtitle } = STEP_DETAILS[step];
+
+  return {
+    title,
+    subtitle,
+    currentStep: index + 1,
+    totalSteps: sequence.length,
+  };
+};
+
+export const getNextStepPath = (plan: PlanType, step: StepKey, searchParams: URLSearchParams) => {
+  const query = searchParams.toString();
+  const suffix = query ? `?${query}` : "";
+
+  if (step === "account") {
+    return plan === "premium" ? `/inscription/paiement${suffix}` : `/inscription/informations${suffix}`;
+  }
+
+  if (step === "payment") {
+    return `/inscription/informations${suffix}`;
+  }
+
+  return "/entrainements";
+};

--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import CTAButton from "@/components/CTAButton";
+import { EXPERIENCE_OPTIONS, GENDER_OPTIONS, MAIN_GOALS } from "@/components/account/constants";
+import BirthDateField from "@/components/account/fields/BirthDateField";
+import DropdownField from "@/components/account/fields/DropdownField";
+import ToggleField from "@/components/account/fields/ToggleField";
+import { createClientComponentClient } from "@/lib/supabase/client";
+
+import StepIndicator from "../components/StepIndicator";
+import { getNextStepPath, getStepMetadata, parsePlan } from "../constants";
+
+type BirthDateParts = {
+  birthDay: string;
+  birthMonth: string;
+  birthYear: string;
+};
+
+type BirthTouchedState = {
+  birthDay: boolean;
+  birthMonth: boolean;
+  birthYear: boolean;
+};
+
+const InformationsPage = () => {
+  const supabase = createClientComponentClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const plan = parsePlan(searchParams.get("plan"));
+  const stepMetadata = getStepMetadata(plan, "profile");
+
+  const [gender, setGender] = useState("");
+  const [birthDay, setBirthDay] = useState("");
+  const [birthMonth, setBirthMonth] = useState("");
+  const [birthYear, setBirthYear] = useState("");
+  const [experience, setExperience] = useState("");
+  const [mainGoal, setMainGoal] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [genderTouched, setGenderTouched] = useState(false);
+  const [experienceTouched, setExperienceTouched] = useState(false);
+  const [mainGoalTouched, setMainGoalTouched] = useState(false);
+  const [birthTouched, setBirthTouched] = useState<BirthTouchedState>({
+    birthDay: false,
+    birthMonth: false,
+    birthYear: false,
+  });
+  const [initialBirthParts, setInitialBirthParts] = useState<BirthDateParts>({
+    birthDay: "",
+    birthMonth: "",
+    birthYear: "",
+  });
+
+  useEffect(() => {
+    const fetchUserMetadata = async () => {
+      const { data } = await supabase.auth.getUser();
+      const metadata = data?.user?.user_metadata as Record<string, unknown> | undefined;
+
+      if (!metadata) return;
+
+      if (typeof metadata.gender === "string") {
+        setGender(metadata.gender);
+      }
+
+      if (typeof metadata.experience_years === "string") {
+        setExperience(metadata.experience_years);
+      }
+
+      if (typeof metadata.main_goal === "string") {
+        setMainGoal(metadata.main_goal);
+      }
+
+      if (typeof metadata.birth_date === "string" && metadata.birth_date.includes("-")) {
+        const [year, month, day] = metadata.birth_date.split("-");
+        const nextBirthParts: BirthDateParts = {
+          birthYear: year || "",
+          birthMonth: month || "",
+          birthDay: day || "",
+        };
+        setBirthYear(nextBirthParts.birthYear);
+        setBirthMonth(nextBirthParts.birthMonth);
+        setBirthDay(nextBirthParts.birthDay);
+        setInitialBirthParts(nextBirthParts);
+      }
+    };
+
+    void fetchUserMetadata();
+    setGenderTouched(false);
+    setExperienceTouched(false);
+    setMainGoalTouched(false);
+    setBirthTouched({
+      birthDay: false,
+      birthMonth: false,
+      birthYear: false,
+    });
+  }, [supabase]);
+
+  const updateBirthTouched = (partial: Partial<BirthTouchedState>) => {
+    setBirthTouched((previous) => ({
+      ...previous,
+      ...partial,
+    }));
+  };
+
+  const isFormComplete =
+    gender !== "" &&
+    birthDay !== "" &&
+    birthMonth !== "" &&
+    birthYear !== "" &&
+    experience !== "" &&
+    mainGoal !== "";
+
+  const searchParamsString = searchParams.toString();
+
+  const nextStepPath = useMemo(() => {
+    if (!plan) {
+      return null;
+    }
+
+    const params = new URLSearchParams(searchParamsString);
+    return getNextStepPath(plan, "profile", params);
+  }, [plan, searchParamsString]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!isFormComplete || loading || !nextStepPath) {
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    const formattedBirthDate = `${birthYear}-${birthMonth}-${birthDay}`;
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        data: {
+          gender,
+          birth_date: formattedBirthDate,
+          experience_years: experience,
+          main_goal: mainGoal,
+        },
+      });
+
+      if (updateError) {
+        setError(updateError.message || "Impossible d'enregistrer vos informations.");
+        setLoading(false);
+        return;
+      }
+
+      router.refresh();
+      router.push(nextStepPath);
+    } catch (submitError) {
+      console.error(submitError);
+      setError("Une erreur est survenue lors de l'enregistrement.");
+      setLoading(false);
+    }
+  };
+
+  if (!plan || !stepMetadata) {
+    return (
+      <main className="min-h-screen bg-[#FBFCFE] flex flex-col items-center justify-center px-4">
+        <div className="max-w-md rounded-[16px] bg-white px-6 py-8 text-center shadow-[0_10px_40px_rgba(46,50,113,0.08)]">
+          <h1 className="text-[26px] font-bold text-[#2E3271]">Choisissez une formule</h1>
+          <p className="mt-3 text-[15px] font-semibold text-[#5D6494]">
+            Pour vous inscrire, sélectionnez d’abord une formule sur la page tarifs.
+          </p>
+          <Link
+            href="/tarifs"
+            className="mt-6 inline-flex items-center justify-center rounded-full bg-[#7069FA] px-5 py-2.5 text-[15px] font-semibold text-white hover:bg-[#6660E4]"
+          >
+            Voir les tarifs
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[60px]">
+      <div className="w-full max-w-3xl flex flex-col items-center">
+        <h1 className="text-center text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{stepMetadata.title}</h1>
+        <p className="mt-2 text-center text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
+          {stepMetadata.subtitle}
+        </p>
+
+        <StepIndicator totalSteps={stepMetadata.totalSteps} currentStep={stepMetadata.currentStep} />
+
+        <form onSubmit={handleSubmit} className="mt-10 mx-auto flex w-full max-w-[420px] flex-col items-center">
+          <div className="w-[368px] rounded-[16px] bg-[#F4F3FF] px-6 py-5 text-center shadow-[0_10px_40px_rgba(46,50,113,0.08)]">
+            <p className="text-[15px] font-semibold text-[#3A416F]">
+              Complétez votre profil et aidez-nous à mieux vous connaître en répondant aux 4 questions ci-dessous.
+            </p>
+          </div>
+
+          {error && (
+            <p className="mt-4 w-[368px] text-left text-[13px] font-semibold text-[#EF4444]">
+              {error}
+            </p>
+          )}
+
+          <div className="mt-6 flex w-full flex-col items-center gap-5">
+            <ToggleField
+              label="Sexe"
+              value={gender}
+              options={Array.from(GENDER_OPTIONS)}
+              onChange={(option) => setGender(option)}
+              touched={genderTouched}
+              setTouched={() => setGenderTouched(true)}
+            />
+
+            <BirthDateField
+              birthDay={birthDay}
+              birthMonth={birthMonth}
+              birthYear={birthYear}
+              setBirthDay={setBirthDay}
+              setBirthMonth={setBirthMonth}
+              setBirthYear={setBirthYear}
+              touched={birthTouched}
+              setTouched={updateBirthTouched}
+              successMessage=""
+              initialBirthDay={initialBirthParts.birthDay}
+              initialBirthMonth={initialBirthParts.birthMonth}
+              initialBirthYear={initialBirthParts.birthYear}
+            />
+
+            <ToggleField
+              label="Années de pratique"
+              value={experience}
+              options={Array.from(EXPERIENCE_OPTIONS)}
+              onChange={(option) => setExperience(option)}
+              touched={experienceTouched}
+              setTouched={() => setExperienceTouched(true)}
+              variant="boxed"
+            />
+
+            <DropdownField
+              label="Quel est votre objectif principal ?"
+              selected={mainGoal}
+              onSelect={(option) => setMainGoal(option)}
+              options={Array.from(MAIN_GOALS).map((goal) => ({ value: goal, label: goal }))}
+              placeholder="Sélectionnez un objectif"
+              touched={mainGoalTouched}
+              setTouched={(value) => setMainGoalTouched(value)}
+            />
+          </div>
+
+          <CTAButton
+            type="submit"
+            loading={loading}
+            disabled={!isFormComplete}
+            variant={!isFormComplete ? "inactive" : "active"}
+            className="mt-6 w-[368px] justify-center font-bold"
+            loadingText="Enregistrement..."
+          >
+            Enregistrer mes informations
+          </CTAButton>
+
+          <Link
+            href="/entrainements"
+            className="mt-4 text-[14px] font-semibold text-[#7069FA] hover:text-[#6660E4]"
+          >
+            Ignorer pour le moment
+          </Link>
+        </form>
+      </div>
+    </main>
+  );
+};
+
+export default InformationsPage;

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -3,82 +3,21 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-import clsx from "clsx";
+import { useMemo, useState } from "react";
 
-import CTAButton from "@/components/CTAButton";
 import { IconCheckbox } from "@/components/ui/IconCheckbox";
 import { createClientComponentClient } from "@/lib/supabase/client";
-import {
-  EXPERIENCE_OPTIONS,
-  GENDER_OPTIONS,
-  MAIN_GOALS,
-} from "@/components/account/constants";
-import BirthDateField from "@/components/account/fields/BirthDateField";
-import DropdownField from "@/components/account/fields/DropdownField";
-import ToggleField from "@/components/account/fields/ToggleField";
 
-type PlanType = "starter" | "premium";
+import StepIndicator from "./components/StepIndicator";
+import { getNextStepPath, getStepMetadata, parsePlan } from "./constants";
 
-type AccountCreationStepProps = {
-  plan: PlanType;
-  onSuccess: () => void;
-};
-
-type PaymentStepProps = {
-  onComplete: () => void;
-};
-
-type ProfileCompletionStepProps = {
-  onSuccessDestination: string;
-};
-
-type BirthDateParts = {
-  birthDay: string;
-  birthMonth: string;
-  birthYear: string;
-};
-
-type BirthTouchedState = {
-  birthDay: boolean;
-  birthMonth: boolean;
-  birthYear: boolean;
-};
-
-const MONTH_OPTIONS = Array.from({ length: 12 }, (_, index) => `${index + 1}`.padStart(2, "0"));
-const CURRENT_YEAR = new Date().getFullYear();
-const PAYMENT_YEAR_OPTIONS = Array.from({ length: 12 }, (_, index) => `${CURRENT_YEAR + index}`);
-
-const StepIndicator = ({
-  totalSteps,
-  currentStep,
-}: {
-  totalSteps: number;
-  currentStep: number;
-}) => {
-  return (
-    <div className="mt-6 flex items-center justify-center gap-2">
-      {Array.from({ length: totalSteps }).map((_, index) => {
-        const step = index + 1;
-        const isActive = step === currentStep;
-        return (
-          <span
-            key={step}
-            aria-hidden
-            className={clsx(
-              "h-[9px] w-[9px] rounded-full transition-colors duration-200",
-              isActive ? "bg-[#A1A5FD]" : "bg-[#ECE9F1]"
-            )}
-          />
-        );
-      })}
-    </div>
-  );
-};
-
-const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
+const AccountCreationPage = () => {
   const supabase = createClientComponentClient();
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const plan = parsePlan(searchParams.get("plan"));
+  const stepMetadata = getStepMetadata(plan, "account");
 
   const [accepted, setAccepted] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -100,7 +39,8 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
   const isPrenomFormatValid = /^[a-zA-ZÀ-ÿ\s-]+$/.test(prenom.trim());
   const isPrenomFieldValid = prenom.trim().length > 0 && isPrenomFormatValid;
   const shouldShowPrenomSuccess = prenomTouched && !prenomFocused && isPrenomFieldValid;
-  const shouldShowPrenomError = prenomTouched && !prenomFocused && prenom.trim() !== "" && !isPrenomFormatValid;
+  const shouldShowPrenomError =
+    prenomTouched && !prenomFocused && prenom.trim() !== "" && !isPrenomFormatValid;
 
   const isEmailValidFormat = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
   const shouldShowEmailSuccess = emailTouched && !emailFocused && isEmailValidFormat;
@@ -117,10 +57,21 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
 
   const isFormValid = accepted && isPrenomFieldValid && isEmailValidFormat && isPasswordValidFormat && !loading;
 
+  const searchParamsString = searchParams.toString();
+
+  const nextStepPath = useMemo(() => {
+    if (!plan) {
+      return null;
+    }
+
+    const params = new URLSearchParams(searchParamsString);
+    return getNextStepPath(plan, "account", params);
+  }, [plan, searchParamsString]);
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!isFormValid) return;
+    if (!isFormValid || !plan || !nextStepPath) return;
 
     setError("");
     setLoading(true);
@@ -155,7 +106,7 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
       }
 
       router.refresh();
-      onSuccess();
+      router.push(nextStepPath);
     } catch (submitError) {
       console.error(submitError);
       setError("Une erreur réseau est survenue.");
@@ -181,595 +132,7 @@ const AccountCreationStep = ({ plan, onSuccess }: AccountCreationStepProps) => {
     );
   };
 
-  return (
-    <form onSubmit={handleSubmit} className="flex w-full max-w-[368px] flex-col items-stretch">
-      <div className="w-full">
-        <label htmlFor="prenom" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
-          Prénom
-        </label>
-        <input
-          id="prenom"
-          name="prenom"
-          type="text"
-          placeholder="John"
-          value={prenom}
-          onChange={(event) => setPrenom(event.target.value)}
-          onFocus={() => setPrenomFocused(true)}
-          onBlur={() => {
-            setPrenomTouched(true);
-            setPrenomFocused(false);
-          }}
-          className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
-            shouldShowPrenomSuccess
-              ? "border border-[#00D591]"
-              : shouldShowPrenomError
-              ? "border border-[#EF4444]"
-              : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-          }`}
-        />
-        <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-          {shouldShowPrenomSuccess && <p className="text-[#00D591]">Enchanté {prenom.trim()} !</p>}
-          {shouldShowPrenomError && <p className="text-[#EF4444]">Le prénom ne doit contenir que des lettres</p>}
-        </div>
-      </div>
-
-      <div className="w-full">
-        <label htmlFor="email" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
-          Adresse e-mail
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          placeholder="john.doe@email.com"
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          onFocus={() => setEmailFocused(true)}
-          onBlur={() => {
-            setEmailTouched(true);
-            setEmailFocused(false);
-          }}
-          className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
-            shouldShowEmailSuccess
-              ? "border border-[#00D591]"
-              : shouldShowEmailError
-              ? "border border-[#EF4444]"
-              : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-          }`}
-        />
-        <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-          {shouldShowEmailSuccess && (
-            <p className="text-[#00D591]">Merci, cet email sera ton identifiant de connexion</p>
-          )}
-          {shouldShowEmailError && <p className="text-[#EF4444]">Format d’adresse invalide</p>}
-        </div>
-      </div>
-
-      <div className="w-full mb-[10px]">
-        <label htmlFor="password" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
-          Mot de passe
-        </label>
-        <div className="relative">
-          <input
-            id="password"
-            name="password"
-            type={showPassword ? "text" : "password"}
-            placeholder="Mot de passe"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            onFocus={() => setPasswordFocused(true)}
-            onBlur={() => {
-              setPasswordTouched(true);
-              setTimeout(() => setPasswordFocused(false), 100);
-            }}
-            className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] pr-10 rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
-              shouldShowPasswordSuccess
-                ? "border border-[#00D591]"
-                : shouldShowPasswordError
-                ? "border border-[#EF4444]"
-                : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-            }`}
-          />
-          <button
-            type="button"
-            onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2"
-          >
-            <Image
-              src={showPassword ? "/icons/masque_defaut.svg" : "/icons/visible_defaut.svg"}
-              alt="Afficher/Masquer"
-              width={25}
-              height={25}
-              className="w-[25px] h-[25px]"
-            />
-          </button>
-        </div>
-        {passwordFocused && (
-          <div
-            className="mt-3 px-4 py-3 bg-white rounded-[8px] text-[12px] text-[#5D6494] space-y-2"
-            style={{
-              boxShadow: "1px 1px 9px 1px rgba(0, 0, 0, 0.12)",
-            }}
-          >
-            <PasswordCriteriaItem valid={hasMinLength} text="Au moins 8 caractères" />
-            <PasswordCriteriaItem valid={hasLetter} text="Au moins 1 lettre" />
-            <PasswordCriteriaItem valid={hasNumber} text="Au moins 1 chiffre" />
-            <PasswordCriteriaItem valid={hasSymbol} text="Au moins 1 symbole" />
-          </div>
-        )}
-        <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-          {shouldShowPasswordSuccess && <p className="text-[#00D591]">Mot de passe valide</p>}
-          {shouldShowPasswordError && <p className="text-[#EF4444]">Mot de passe invalide</p>}
-        </div>
-      </div>
-
-      <div className="mb-[20px] w-full">
-        <label className="flex items-start gap-3 cursor-pointer select-none text-[14px] font-semibold text-[#5D6494]">
-          <IconCheckbox
-            checked={accepted}
-            onChange={(event) => setAccepted(event.target.checked)}
-            size={15}
-            containerClassName="mt-[3px]"
-          />
-          <span className="mt-[-3px]">
-            J’accepte la{" "}
-            <Link href="#" className="text-[#7069FA] hover:text-[#6660E4]">
-              Politique de confidentialité
-            </Link>{" "}
-            et les{" "}
-            <Link href="#" className="text-[#7069FA] hover:text-[#6660E4]">
-              Conditions générales d’utilisation
-            </Link>{" "}
-            de Glift.
-          </span>
-        </label>
-      </div>
-
-      {error && <p className="text-[#EF4444] mb-4 text-sm text-center max-w-[368px]">{error}</p>}
-
-      <div className="w-full flex justify-center mt-[10px]">
-        <button
-          type="submit"
-          disabled={!isFormValid}
-          className={`w-full max-w-[220px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2 ${
-            isFormValid
-              ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
-              : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
-          }`}
-        >
-          <Image
-            src="/icons/cadena_defaut.svg"
-            alt="Icône cadenas"
-            width={20}
-            height={20}
-            className={`w-[20px] h-[20px] transition-colors ${isFormValid ? "invert brightness-0" : ""}`}
-          />
-          {loading ? "En cours..." : "Créer mon compte"}
-        </button>
-      </div>
-
-      <p className="mt-[20px] text-sm font-semibold text-[#5D6494] text-center self-center">
-        Déjà inscrit ?{" "}
-        <Link href="/connexion" className="text-[#7069FA] hover:text-[#6660E4]">
-          Connectez-vous
-        </Link>
-      </p>
-    </form>
-  );
-};
-
-const PaymentStep = ({ onComplete }: PaymentStepProps) => {
-  const [cardHolder, setCardHolder] = useState("");
-  const [cardNumber, setCardNumber] = useState("");
-  const [expiryMonth, setExpiryMonth] = useState("");
-  const [expiryYear, setExpiryYear] = useState("");
-  const [cvc, setCvc] = useState("");
-  const [termsAccepted, setTermsAccepted] = useState(false);
-  const [loading, setLoading] = useState(false);
-
-  const sanitizeCardNumber = (value: string) => value.replace(/[^0-9]/g, "");
-
-  const formattedCardNumber = useMemo(() => {
-    return cardNumber.replace(/(.{4})/g, "$1 ").trim();
-  }, [cardNumber]);
-
-  const handleCardNumberChange = (value: string) => {
-    const sanitized = sanitizeCardNumber(value).slice(0, 19);
-    setCardNumber(sanitized);
-  };
-
-  const handleCvcChange = (value: string) => {
-    const sanitized = value.replace(/[^0-9]/g, "").slice(0, 4);
-    setCvc(sanitized);
-  };
-
-  const isCardNumberValid = sanitizeCardNumber(cardNumber).length >= 12;
-  const isCvcValid = /^\d{3,4}$/.test(cvc);
-  const isFormValid =
-    cardHolder.trim().length > 0 &&
-    isCardNumberValid &&
-    expiryMonth !== "" &&
-    expiryYear !== "" &&
-    isCvcValid &&
-    termsAccepted &&
-    !loading;
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!isFormValid) return;
-
-    setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-      onComplete();
-    }, 400);
-  };
-
-  return (
-    <form
-      onSubmit={handleSubmit}
-      className="mx-auto w-full max-w-[460px] rounded-[16px] bg-white px-6 py-8 shadow-[0_10px_40px_rgba(46,50,113,0.08)]"
-    >
-      <div className="rounded-[12px] bg-[#F6F5FF] px-4 py-3 text-sm font-semibold text-[#5D6494]">
-        <p className="text-[#3A416F] text-[15px] font-bold mb-1">Paiement 100% sécurisé</p>
-        <p>
-          Pour activer votre essai gratuit, nous avons besoin de vos informations de paiement. Vous ne serez pas facturé avant le
-          31/05/2025.
-        </p>
-      </div>
-
-      <div className="mt-6 space-y-4">
-        <div>
-          <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Nom du titulaire de la carte</label>
-          <input
-            value={cardHolder}
-            onChange={(event) => setCardHolder(event.target.value)}
-            placeholder="John Doe"
-            className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
-          />
-        </div>
-        <div>
-          <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Numéro de carte</label>
-          <input
-            value={formattedCardNumber}
-            onChange={(event) => handleCardNumberChange(event.target.value)}
-            placeholder="1111 2222 3333 4444"
-            inputMode="numeric"
-            className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Date d’expiration</label>
-            <div className="flex gap-2">
-              <select
-                value={expiryMonth}
-                onChange={(event) => setExpiryMonth(event.target.value)}
-                className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] bg-white px-3 text-[16px] font-semibold text-[#5D6494] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
-              >
-                <option value="">MM</option>
-                {MONTH_OPTIONS.map((month) => (
-                  <option key={month} value={month}>
-                    {month}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={expiryYear}
-                onChange={(event) => setExpiryYear(event.target.value)}
-                className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] bg-white px-3 text-[16px] font-semibold text-[#5D6494] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
-              >
-                <option value="">AAAA</option>
-                {PAYMENT_YEAR_OPTIONS.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-          <div>
-            <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Code de sécurité</label>
-            <input
-              value={cvc}
-              onChange={(event) => handleCvcChange(event.target.value)}
-              placeholder="123"
-              inputMode="numeric"
-              className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
-            />
-          </div>
-        </div>
-      </div>
-
-      <label className="mt-6 flex items-start gap-3 text-[13px] font-semibold text-[#5D6494] cursor-pointer">
-        <IconCheckbox
-          checked={termsAccepted}
-          onChange={(event) => setTermsAccepted(event.target.checked)}
-          size={16}
-          containerClassName="mt-[3px]"
-        />
-        <span>
-          Je confirme que je m’abonne à un service facturé 2,49 €/mois, renouvelé automatiquement à la fin de la période d’essai
-          et annulable à tout moment. J’autorise le prélèvement automatique sur ma carte bancaire et reconnais avoir lu et accepté
-          les conditions d’utilisation et la politique de confidentialité.
-        </span>
-      </label>
-
-      <button
-        type="submit"
-        disabled={!isFormValid}
-        className={`mt-6 flex w-full items-center justify-center gap-2 rounded-full bg-[#7069FA] px-6 py-3 text-[16px] font-semibold text-white transition-colors ${
-          isFormValid ? "hover:bg-[#6660E4]" : "opacity-50 cursor-not-allowed"
-        }`}
-      >
-        <Image src="/icons/arrow.svg" alt="Icône flèche" width={20} height={20} />
-        {loading ? "Traitement..." : "Démarrer mon abonnement"}
-      </button>
-
-      <div className="mt-4 flex items-center justify-center gap-2 text-[13px] font-semibold text-[#5D6494]">
-        <Image src="/icons/cadena_stripe.svg" alt="Cadenas" width={18} height={18} />
-        <span>Paiement 100% sécurisé par</span>
-        <Image src="/icons/logo_stripe.svg" alt="Stripe" width={48} height={18} />
-      </div>
-    </form>
-  );
-};
-
-const ProfileCompletionStep = ({ onSuccessDestination }: ProfileCompletionStepProps) => {
-  const supabase = createClientComponentClient();
-  const router = useRouter();
-
-  const [gender, setGender] = useState("");
-  const [birthDay, setBirthDay] = useState("");
-  const [birthMonth, setBirthMonth] = useState("");
-  const [birthYear, setBirthYear] = useState("");
-  const [experience, setExperience] = useState("");
-  const [mainGoal, setMainGoal] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const [genderTouched, setGenderTouched] = useState(false);
-  const [experienceTouched, setExperienceTouched] = useState(false);
-  const [mainGoalTouched, setMainGoalTouched] = useState(false);
-  const [birthTouched, setBirthTouched] = useState<BirthTouchedState>({
-    birthDay: false,
-    birthMonth: false,
-    birthYear: false,
-  });
-  const [initialBirthParts, setInitialBirthParts] = useState<BirthDateParts>({
-    birthDay: "",
-    birthMonth: "",
-    birthYear: "",
-  });
-
-  useEffect(() => {
-    const fetchUserMetadata = async () => {
-      const { data } = await supabase.auth.getUser();
-      const metadata = data?.user?.user_metadata as Record<string, unknown> | undefined;
-
-      if (!metadata) return;
-
-      if (typeof metadata.gender === "string") {
-        setGender(metadata.gender);
-      }
-
-      if (typeof metadata.experience_years === "string") {
-        setExperience(metadata.experience_years);
-      }
-
-      if (typeof metadata.main_goal === "string") {
-        setMainGoal(metadata.main_goal);
-      }
-
-      if (typeof metadata.birth_date === "string" && metadata.birth_date.includes("-")) {
-        const [year, month, day] = metadata.birth_date.split("-");
-        const nextBirthParts: BirthDateParts = {
-          birthYear: year || "",
-          birthMonth: month || "",
-          birthDay: day || "",
-        };
-        setBirthYear(nextBirthParts.birthYear);
-        setBirthMonth(nextBirthParts.birthMonth);
-        setBirthDay(nextBirthParts.birthDay);
-        setInitialBirthParts(nextBirthParts);
-      }
-    };
-
-    void fetchUserMetadata();
-    setGenderTouched(false);
-    setExperienceTouched(false);
-    setMainGoalTouched(false);
-    setBirthTouched({
-      birthDay: false,
-      birthMonth: false,
-      birthYear: false,
-    });
-  }, [supabase]);
-
-  const updateBirthTouched = (partial: Partial<BirthTouchedState>) => {
-    setBirthTouched((previous) => ({
-      ...previous,
-      ...partial,
-    }));
-  };
-
-  const isFormComplete =
-    gender !== "" &&
-    birthDay !== "" &&
-    birthMonth !== "" &&
-    birthYear !== "" &&
-    experience !== "" &&
-    mainGoal !== "";
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!isFormComplete || loading) {
-      return;
-    }
-
-    setError(null);
-    setLoading(true);
-
-    const formattedBirthDate = `${birthYear}-${birthMonth}-${birthDay}`;
-
-    try {
-      const { error: updateError } = await supabase.auth.updateUser({
-        data: {
-          gender,
-          birth_date: formattedBirthDate,
-          experience_years: experience,
-          main_goal: mainGoal,
-        },
-      });
-
-      if (updateError) {
-        setError(updateError.message || "Impossible d'enregistrer vos informations.");
-        setLoading(false);
-        return;
-      }
-
-      router.refresh();
-      router.push(onSuccessDestination);
-    } catch (submitError) {
-      console.error(submitError);
-      setError("Une erreur est survenue lors de l'enregistrement.");
-      setLoading(false);
-    }
-  };
-
-  const isSubmitDisabled = !isFormComplete;
-
-  return (
-    <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-[420px] flex-col items-center">
-      <div className="w-[368px] rounded-[16px] bg-[#F4F3FF] px-6 py-5 text-center shadow-[0_10px_40px_rgba(46,50,113,0.08)]">
-        <p className="text-[15px] font-semibold text-[#3A416F]">
-          Complétez votre profil et aidez-nous à mieux vous connaître en répondant aux 4 questions ci-dessous.
-        </p>
-      </div>
-
-      {error && (
-        <p className="mt-4 w-[368px] text-left text-[13px] font-semibold text-[#EF4444]">
-          {error}
-        </p>
-      )}
-
-      <div className="mt-6 flex w-full flex-col items-center gap-5">
-        <ToggleField
-          label="Sexe"
-          value={gender}
-          options={Array.from(GENDER_OPTIONS)}
-          onChange={(option) => setGender(option)}
-          touched={genderTouched}
-          setTouched={() => setGenderTouched(true)}
-        />
-
-        <BirthDateField
-          birthDay={birthDay}
-          birthMonth={birthMonth}
-          birthYear={birthYear}
-          setBirthDay={setBirthDay}
-          setBirthMonth={setBirthMonth}
-          setBirthYear={setBirthYear}
-          touched={birthTouched}
-          setTouched={updateBirthTouched}
-          successMessage=""
-          initialBirthDay={initialBirthParts.birthDay}
-          initialBirthMonth={initialBirthParts.birthMonth}
-          initialBirthYear={initialBirthParts.birthYear}
-        />
-
-        <ToggleField
-          label="Années de pratique"
-          value={experience}
-          options={Array.from(EXPERIENCE_OPTIONS)}
-          onChange={(option) => setExperience(option)}
-          touched={experienceTouched}
-          setTouched={() => setExperienceTouched(true)}
-          variant="boxed"
-        />
-
-        <DropdownField
-          label="Quel est votre objectif principal ?"
-          selected={mainGoal}
-          onSelect={(option) => setMainGoal(option)}
-          options={Array.from(MAIN_GOALS).map((goal) => ({ value: goal, label: goal }))}
-          placeholder="Sélectionnez un objectif"
-          touched={mainGoalTouched}
-          setTouched={(value) => setMainGoalTouched(value)}
-        />
-      </div>
-
-      <CTAButton
-        type="submit"
-        loading={loading}
-        disabled={isSubmitDisabled}
-        variant={isSubmitDisabled ? "inactive" : "active"}
-        className="mt-6 w-[368px] justify-center font-bold"
-        loadingText="Enregistrement..."
-      >
-        Enregistrer mes informations
-      </CTAButton>
-
-      <Link
-        href="/entrainements"
-        className="mt-4 text-[14px] font-semibold text-[#7069FA] hover:text-[#6660E4]"
-      >
-        Ignorer pour le moment
-      </Link>
-    </form>
-  );
-};
-
-const InscriptionPage = () => {
-  const searchParams = useSearchParams();
-  const planParam = searchParams.get("plan");
-
-  const plan = planParam === "premium" || planParam === "starter" ? (planParam as PlanType) : null;
-
-  const [currentStep, setCurrentStep] = useState(1);
-
-  useEffect(() => {
-    setCurrentStep(1);
-  }, [plan]);
-
-  const totalSteps = plan === "premium" ? 3 : 2;
-
-  const stepDetails = useMemo(() => {
-    if (plan === "premium") {
-      return [
-        {
-          title: "Création de votre compte",
-          subtitle: "Créez un compte en moins d’une minute pour commencer à utiliser la plateforme Glift.",
-        },
-        {
-          title: "Mode de paiement",
-          subtitle: "Activez votre essai gratuit en renseignant vos informations de paiement.",
-        },
-        {
-          title: "Inscription terminée !",
-          subtitle: "Complétez votre profil pour personnaliser vos entraînements.",
-        },
-      ];
-    }
-
-    if (plan === "starter") {
-      return [
-        {
-          title: "Création de votre compte",
-          subtitle: "Créez un compte en moins d’une minute pour commencer à utiliser la plateforme Glift.",
-        },
-        {
-          title: "Inscription terminée !",
-          subtitle: "Complétez votre profil pour personnaliser vos entraînements.",
-        },
-      ];
-    }
-
-    return [];
-  }, [plan]);
-
-  if (!plan) {
+  if (!plan || !stepMetadata) {
     return (
       <main className="min-h-screen bg-[#FBFCFE] flex flex-col items-center justify-center px-4">
         <div className="max-w-md rounded-[16px] bg-white px-6 py-8 text-center shadow-[0_10px_40px_rgba(46,50,113,0.08)]">
@@ -788,44 +151,192 @@ const InscriptionPage = () => {
     );
   }
 
-  const activeStep = stepDetails[currentStep - 1];
-
-  let stepContent: ReactNode = null;
-
-  if (currentStep === 1) {
-    stepContent = (
-      <AccountCreationStep
-        plan={plan}
-        onSuccess={() => setCurrentStep((previous) => Math.min(previous + 1, totalSteps))}
-      />
-    );
-  } else if (plan === "starter") {
-    stepContent = <ProfileCompletionStep onSuccessDestination="/compte#mes-informations" />;
-  } else {
-    if (currentStep === 2) {
-      stepContent = <PaymentStep onComplete={() => setCurrentStep(3)} />;
-    } else {
-      stepContent = <ProfileCompletionStep onSuccessDestination="/compte#mes-informations" />;
-    }
-  }
-
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[60px]">
       <div className="w-full max-w-3xl flex flex-col items-center">
-        {activeStep && (
-          <>
-            <h1 className="text-center text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{activeStep.title}</h1>
-            <p className="mt-2 text-center text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
-              {activeStep.subtitle}
-            </p>
-          </>
-        )}
-        <StepIndicator totalSteps={totalSteps} currentStep={currentStep} />
+        <h1 className="text-center text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{stepMetadata.title}</h1>
+        <p className="mt-2 text-center text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
+          {stepMetadata.subtitle}
+        </p>
 
-        <div className="mt-10 w-full flex justify-center">{stepContent}</div>
+        <StepIndicator totalSteps={stepMetadata.totalSteps} currentStep={stepMetadata.currentStep} />
+
+        <form onSubmit={handleSubmit} className="mt-10 flex w-full max-w-[368px] flex-col items-stretch">
+          <div className="w-full">
+            <label htmlFor="prenom" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
+              Prénom
+            </label>
+            <input
+              id="prenom"
+              name="prenom"
+              type="text"
+              placeholder="John"
+              value={prenom}
+              onChange={(event) => setPrenom(event.target.value)}
+              onFocus={() => setPrenomFocused(true)}
+              onBlur={() => {
+                setPrenomTouched(true);
+                setPrenomFocused(false);
+              }}
+              className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
+                shouldShowPrenomSuccess
+                  ? "border border-[#00D591]"
+                  : shouldShowPrenomError
+                  ? "border border-[#EF4444]"
+                  : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+              }`}
+            />
+            <div className="h-[20px] mt-[5px] text-[13px] font-medium">
+              {shouldShowPrenomSuccess && <p className="text-[#00D591]">Enchanté {prenom.trim()} !</p>}
+              {shouldShowPrenomError && <p className="text-[#EF4444]">Le prénom ne doit contenir que des lettres</p>}
+            </div>
+          </div>
+
+          <div className="w-full">
+            <label htmlFor="email" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
+              Adresse e-mail
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="john.doe@email.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              onFocus={() => setEmailFocused(true)}
+              onBlur={() => {
+                setEmailTouched(true);
+                setEmailFocused(false);
+              }}
+              className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
+                shouldShowEmailSuccess
+                  ? "border border-[#00D591]"
+                  : shouldShowEmailError
+                  ? "border border-[#EF4444]"
+                  : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+              }`}
+            />
+            <div className="h-[20px] mt-[5px] text-[13px] font-medium">
+              {shouldShowEmailSuccess && (
+                <p className="text-[#00D591]">Merci, cet email sera ton identifiant de connexion</p>
+              )}
+              {shouldShowEmailError && <p className="text-[#EF4444]">Format d’adresse invalide</p>}
+            </div>
+          </div>
+
+          <div className="w-full mb-[10px]">
+            <label htmlFor="password" className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">
+              Mot de passe
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                name="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Mot de passe"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                onFocus={() => setPasswordFocused(true)}
+                onBlur={() => {
+                  setPasswordTouched(true);
+                  setTimeout(() => setPasswordFocused(false), 100);
+                }}
+                className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] pr-10 rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
+                  shouldShowPasswordSuccess
+                    ? "border border-[#00D591]"
+                    : shouldShowPasswordError
+                    ? "border border-[#EF4444]"
+                    : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+                }`}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2"
+              >
+                <Image
+                  src={showPassword ? "/icons/masque_defaut.svg" : "/icons/visible_defaut.svg"}
+                  alt="Afficher/Masquer"
+                  width={25}
+                  height={25}
+                  className="w-[25px] h-[25px]"
+                />
+              </button>
+            </div>
+            {passwordFocused && (
+              <div
+                className="mt-3 px-4 py-3 bg-white rounded-[8px] text-[12px] text-[#5D6494] space-y-2"
+                style={{
+                  boxShadow: "1px 1px 9px 1px rgba(0, 0, 0, 0.12)",
+                }}
+              >
+                <PasswordCriteriaItem valid={hasMinLength} text="Au moins 8 caractères" />
+                <PasswordCriteriaItem valid={hasLetter} text="Au moins 1 lettre" />
+                <PasswordCriteriaItem valid={hasNumber} text="Au moins 1 chiffre" />
+                <PasswordCriteriaItem valid={hasSymbol} text="Au moins 1 symbole" />
+              </div>
+            )}
+            <div className="h-[20px] mt-[5px] text-[13px] font-medium">
+              {shouldShowPasswordSuccess && <p className="text-[#00D591]">Mot de passe valide</p>}
+              {shouldShowPasswordError && <p className="text-[#EF4444]">Mot de passe invalide</p>}
+            </div>
+          </div>
+
+          <div className="mb-[20px] w-full">
+            <label className="flex items-start gap-3 cursor-pointer select-none text-[14px] font-semibold text-[#5D6494]">
+              <IconCheckbox
+                checked={accepted}
+                onChange={(event) => setAccepted(event.target.checked)}
+                size={15}
+                containerClassName="mt-[3px]"
+              />
+              <span className="mt-[-3px]">
+                J’accepte la{" "}
+                <Link href="#" className="text-[#7069FA] hover:text-[#6660E4]">
+                  Politique de confidentialité
+                </Link>{" "}
+                et les{" "}
+                <Link href="#" className="text-[#7069FA] hover:text-[#6660E4]">
+                  Conditions générales d’utilisation
+                </Link>{" "}
+                de Glift.
+              </span>
+            </label>
+          </div>
+
+          {error && <p className="text-[#EF4444] mb-4 text-sm text-center max-w-[368px]">{error}</p>}
+
+          <div className="w-full flex justify-center mt-[10px]">
+            <button
+              type="submit"
+              disabled={!isFormValid}
+              className={`w-full max-w-[220px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2 ${
+                isFormValid
+                  ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
+                  : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
+              }`}
+            >
+              <Image
+                src="/icons/cadena_defaut.svg"
+                alt="Icône cadenas"
+                width={20}
+                height={20}
+                className={`w-[20px] h-[20px] transition-colors ${isFormValid ? "invert brightness-0" : ""}`}
+              />
+              {loading ? "En cours..." : "Créer mon compte"}
+            </button>
+          </div>
+
+          <p className="mt-[20px] text-sm font-semibold text-[#5D6494] text-center self-center">
+            Déjà inscrit ?{" "}
+            <Link href="/connexion" className="text-[#7069FA] hover:text-[#6660E4]">
+              Connectez-vous
+            </Link>
+          </p>
+        </form>
       </div>
     </main>
   );
 };
 
-export default InscriptionPage;
+export default AccountCreationPage;

--- a/src/app/inscription/paiement/page.tsx
+++ b/src/app/inscription/paiement/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import { IconCheckbox } from "@/components/ui/IconCheckbox";
+
+import StepIndicator from "../components/StepIndicator";
+import { getNextStepPath, getStepMetadata, parsePlan } from "../constants";
+
+const PaymentPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const plan = parsePlan(searchParams.get("plan"));
+  const stepMetadata = getStepMetadata(plan, "payment");
+
+  const [cardHolder, setCardHolder] = useState("");
+  const [cardNumber, setCardNumber] = useState("");
+  const [expiryMonth, setExpiryMonth] = useState("");
+  const [expiryYear, setExpiryYear] = useState("");
+  const [cvc, setCvc] = useState("");
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const sanitizeCardNumber = (value: string) => value.replace(/[^0-9]/g, "");
+
+  const formattedCardNumber = useMemo(() => {
+    return cardNumber.replace(/(.{4})/g, "$1 ").trim();
+  }, [cardNumber]);
+
+  const handleCardNumberChange = (value: string) => {
+    const sanitized = sanitizeCardNumber(value).slice(0, 19);
+    setCardNumber(sanitized);
+  };
+
+  const handleCvcChange = (value: string) => {
+    const sanitized = value.replace(/[^0-9]/g, "").slice(0, 4);
+    setCvc(sanitized);
+  };
+
+  const isCardNumberValid = sanitizeCardNumber(cardNumber).length >= 12;
+  const isCvcValid = /^\d{3,4}$/.test(cvc);
+  const isFormValid =
+    cardHolder.trim().length > 0 &&
+    isCardNumberValid &&
+    expiryMonth !== "" &&
+    expiryYear !== "" &&
+    isCvcValid &&
+    termsAccepted &&
+    !loading;
+
+  const searchParamsString = searchParams.toString();
+
+  const nextStepPath = useMemo(() => {
+    if (!plan) {
+      return null;
+    }
+
+    const params = new URLSearchParams(searchParamsString);
+    return getNextStepPath(plan, "payment", params);
+  }, [plan, searchParamsString]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!isFormValid || !stepMetadata || !nextStepPath) {
+      return;
+    }
+
+    setLoading(true);
+
+    setTimeout(() => {
+      setLoading(false);
+      router.push(nextStepPath);
+    }, 400);
+  };
+
+  if (!plan || plan !== "premium" || !stepMetadata) {
+    return (
+      <main className="min-h-screen bg-[#FBFCFE] flex flex-col items-center justify-center px-4">
+        <div className="max-w-md rounded-[16px] bg-white px-6 py-8 text-center shadow-[0_10px_40px_rgba(46,50,113,0.08)]">
+          <h1 className="text-[26px] font-bold text-[#2E3271]">Redirection nécessaire</h1>
+          <p className="mt-3 text-[15px] font-semibold text-[#5D6494]">
+            Cette étape est réservée à la formule Premium. Reprenez le tunnel d’inscription depuis la première étape.
+          </p>
+          <Link
+            href="/inscription"
+            className="mt-6 inline-flex items-center justify-center rounded-full bg-[#7069FA] px-5 py-2.5 text-[15px] font-semibold text-white hover:bg-[#6660E4]"
+          >
+            Retour à l’inscription
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[60px]">
+      <div className="w-full max-w-3xl flex flex-col items-center">
+        <h1 className="text-center text-[26px] sm:text-[30px] font-bold text-[#2E3271]">{stepMetadata.title}</h1>
+        <p className="mt-2 text-center text-[15px] sm:text-[16px] font-semibold text-[#5D6494] leading-snug">
+          {stepMetadata.subtitle}
+        </p>
+
+        <StepIndicator totalSteps={stepMetadata.totalSteps} currentStep={stepMetadata.currentStep} />
+
+        <form
+          onSubmit={handleSubmit}
+          className="mt-10 mx-auto w-full max-w-[460px] rounded-[16px] bg-white px-6 py-8 shadow-[0_10px_40px_rgba(46,50,113,0.08)]"
+        >
+          <div className="rounded-[12px] bg-[#F6F5FF] px-4 py-3 text-sm font-semibold text-[#5D6494]">
+            <p className="text-[#3A416F] text-[15px] font-bold mb-1">Paiement 100% sécurisé</p>
+            <p>
+              Pour activer votre essai gratuit, nous avons besoin de vos informations de paiement. Vous ne serez pas facturé avant le 31/05/2025.
+            </p>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div>
+              <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Nom du titulaire de la carte</label>
+              <input
+                value={cardHolder}
+                onChange={(event) => setCardHolder(event.target.value)}
+                placeholder="John Doe"
+                className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+              />
+            </div>
+            <div>
+              <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Numéro de carte</label>
+              <input
+                value={formattedCardNumber}
+                onChange={(event) => handleCardNumberChange(event.target.value)}
+                placeholder="1111 2222 3333 4444"
+                inputMode="numeric"
+                className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Date d’expiration</label>
+                <div className="flex gap-2">
+                  <select
+                    value={expiryMonth}
+                    onChange={(event) => setExpiryMonth(event.target.value)}
+                    className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] bg-white px-3 text-[16px] font-semibold text-[#5D6494] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+                  >
+                    <option value="">MM</option>
+                    {Array.from({ length: 12 }).map((_, index) => {
+                      const month = `${index + 1}`.padStart(2, "0");
+                      return (
+                        <option key={month} value={month}>
+                          {month}
+                        </option>
+                      );
+                    })}
+                  </select>
+                  <select
+                    value={expiryYear}
+                    onChange={(event) => setExpiryYear(event.target.value)}
+                    className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] bg-white px-3 text-[16px] font-semibold text-[#5D6494] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+                  >
+                    <option value="">AAAA</option>
+                    {Array.from({ length: 12 }).map((_, index) => {
+                      const year = `${new Date().getFullYear() + index}`;
+                      return (
+                        <option key={year} value={year}>
+                          {year}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="mb-2 block text-[14px] font-semibold text-[#3A416F]">Code de sécurité</label>
+                <input
+                  value={cvc}
+                  onChange={(event) => handleCvcChange(event.target.value)}
+                  placeholder="123"
+                  inputMode="numeric"
+                  className="h-[45px] w-full rounded-[8px] border border-[#D7D4DC] px-4 text-[16px] font-semibold text-[#5D6494] placeholder-[#D7D4DC] focus:border-[#A1A5FD] focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+                />
+              </div>
+            </div>
+          </div>
+
+          <label className="mt-6 flex items-start gap-3 text-[13px] font-semibold text-[#5D6494] cursor-pointer">
+            <IconCheckbox
+              checked={termsAccepted}
+              onChange={(event) => setTermsAccepted(event.target.checked)}
+              size={16}
+              containerClassName="mt-[3px]"
+            />
+            <span>
+              Je confirme que je m’abonne à un service facturé 2,49 €/mois, renouvelé automatiquement à la fin de la période d’essai et annulable à tout moment. J’autorise le prélèvement automatique sur ma carte bancaire et reconnais avoir lu et accepté les conditions d’utilisation et la politique de confidentialité.
+            </span>
+          </label>
+
+          <button
+            type="submit"
+            disabled={!isFormValid}
+            className={`mt-6 flex w-full items-center justify-center gap-2 rounded-full bg-[#7069FA] px-6 py-3 text-[16px] font-semibold text-white transition-colors ${
+              isFormValid ? "hover:bg-[#6660E4]" : "opacity-50 cursor-not-allowed"
+            }`}
+          >
+            <Image src="/icons/arrow.svg" alt="Icône flèche" width={20} height={20} />
+            {loading ? "Traitement..." : "Démarrer mon abonnement"}
+          </button>
+
+          <div className="mt-4 flex items-center justify-center gap-2 text-[13px] font-semibold text-[#5D6494]">
+            <Image src="/icons/cadena_stripe.svg" alt="Cadenas" width={18} height={18} />
+            <span>Paiement 100% sécurisé par</span>
+            <Image src="/icons/logo_stripe.svg" alt="Stripe" width={48} height={18} />
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+};
+
+export default PaymentPage;


### PR DESCRIPTION
## Summary
- split the onboarding flow into dedicated routes for account creation, payment, and profile completion
- add shared step metadata helpers and a reusable step indicator component for consistent progress UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da4eb4c284832e96ba318f5d2b93f2