### PR TITLE
Use Next.js Image components for training and payment icons

### DIFF
--- a/public/icons/arrow_grey.svg
+++ b/public/icons/arrow_grey.svg
@@ -1,0 +1,5 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="14.3697" height="2.31429" rx="1.15714" transform="matrix(1 0 0 -1 4.5 14.4067)" fill="#D7D4DC" />
+  <rect width="10.5378" height="2.31429" rx="1.15714" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 13.9211 20.8064)" fill="#D7D4DC" />
+  <rect width="10.5378" height="2.31429" rx="1.15714" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 21.3994 13.1851)" fill="#D7D4DC" />
+</svg>

--- a/src/app/inscription/paiement/page.tsx
+++ b/src/app/inscription/paiement/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-/* eslint-disable @next/next/no-img-element */
-
+import Image from "next/image";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -114,17 +113,21 @@ const PaymentPage = () => {
               onChange={(event) => setAccepted(event.target.checked)}
               className="peer sr-only"
             />
-            <img
+            <Image
               src="/icons/checkbox_unchecked.svg"
               alt=""
               aria-hidden="true"
-              className="absolute inset-0 w-[15px] h-[15px] peer-checked:hidden"
+              fill
+              sizes="15px"
+              className="peer-checked:hidden object-contain"
             />
-            <img
+            <Image
               src="/icons/checkbox_checked.svg"
               alt=""
               aria-hidden="true"
-              className="absolute inset-0 w-[15px] h-[15px] hidden peer-checked:block"
+              fill
+              sizes="15px"
+              className="hidden peer-checked:block object-contain"
             />
           </div>
           <span className="leading-relaxed">
@@ -150,16 +153,16 @@ const PaymentPage = () => {
             ) : (
               <>
                 Démarrer mon abonnement
-                <img src={arrowIcon} alt="" aria-hidden="true" className="w-[25px] h-[25px] ml-1" />
+                <Image src={arrowIcon} alt="" aria-hidden="true" width={25} height={25} className="ml-1" />
               </>
             )}
           </button>
         </div>
 
         <div className="mt-5 flex items-center justify-center gap-2 text-[12px] font-semibold text-[#5D6494]">
-          <img src="/icons/cadena_stripe.svg" alt="Sécurisé" className="h-[16px] w-auto mt-[-3px]" />
+          <Image src="/icons/cadena_stripe.svg" alt="Sécurisé" width={16} height={16} className="mt-[-3px]" />
           <span>Paiement 100% sécurisé par</span>
-          <img src="/icons/logo_stripe.svg" alt="Stripe" className="h-[16px] w-auto ml-[-3px]" />
+          <Image src="/icons/logo_stripe.svg" alt="Stripe" width={16} height={16} className="ml-[-3px]" />
         </div>
       </div>
     </main>

--- a/src/components/TrainingRow.tsx
+++ b/src/components/TrainingRow.tsx
@@ -203,14 +203,14 @@ export default function TrainingRow({
               className="w-5 h-3 flex items-center justify-center mb-1"
               disabled={row.series >= 6}
             >
-              <img src="/icons/chevron_training_up.svg" alt="+" />
+              <Image src="/icons/chevron_training_up.svg" alt="Augmenter le nombre de séries" width={16} height={8} />
             </button>
             <button
               onClick={() => handleDecrementSeries(index)}
               className="w-5 h-3 flex items-center justify-center"
               disabled={row.series <= 1}
             >
-              <img src="/icons/chevron_training_down.svg" alt="-" />
+              <Image src="/icons/chevron_training_down.svg" alt="Diminuer le nombre de séries" width={16} height={8} />
             </button>
           </div>
         </div>
@@ -305,7 +305,7 @@ export default function TrainingRow({
             {row.effort.map((eff, subIndex) => (
               <div key={`effort-${subIndex}`} className="flex items-center justify-center w-full border-l h-10">
                 <div className="flex justify-center items-center w-full">
-                  <img
+                  <Image
                     src={
                       eff === "trop facile"
                         ? "/icons/smiley_easy.svg"
@@ -315,6 +315,8 @@ export default function TrainingRow({
                     }
                     alt="Effort"
                     className="w-6 h-6"
+                    width={24}
+                    height={24}
                   />
                 </div>
                 <div className="flex flex-col items-center ml-auto">
@@ -323,14 +325,14 @@ export default function TrainingRow({
                     onClick={() => handleEffortChange(index, subIndex, "up")}
                     disabled={eff === "trop facile"}
                   >
-                    <img src="/icons/chevron_training_up.svg" alt="+" />
+                    <Image src="/icons/chevron_training_up.svg" alt="Augmenter l'effort" width={16} height={8} />
                   </button>
                   <button
                     className="w-5 h-3 flex items-center justify-center"
                     onClick={() => handleEffortChange(index, subIndex, "down")}
                     disabled={eff === "trop dur"}
                   >
-                    <img src="/icons/chevron_training_down.svg" alt="-" />
+                    <Image src="/icons/chevron_training_down.svg" alt="Diminuer l'effort" width={16} height={8} />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace legacy <img> usage in the training row with Next.js Image components to satisfy linting and optimize icons
- update the payment page to rely on Next.js Image for checkboxes and decorative icons while removing the lint suppression
- add the missing disabled arrow asset referenced by the payment CTA

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da5bc24f5c832ebfa65c98db9b54e3