### PR TITLE
Stabilize Supabase client across admin interfaces

### DIFF
--- a/src/app/admin/components/ImageUploader.tsx
+++ b/src/app/admin/components/ImageUploader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { createClient } from "@/lib/supabaseClient";
 
@@ -11,7 +11,7 @@ type Props = {
 
 export default function ImageUploader({ value, onChange }: Props) {
   const [loading, setLoading] = useState(false);
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/admin/create-offer/page.tsx
+++ b/src/app/admin/create-offer/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
 import ImageUploader from "@/app/admin/components/ImageUploader";
@@ -59,7 +59,7 @@ const offerTypes = [
 ];
 
 export default function CreateOfferPage() {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
 

--- a/src/app/admin/create-program/page.tsx
+++ b/src/app/admin/create-program/page.tsx
@@ -28,7 +28,7 @@ type Program = {
 };
 
 export default function CreateProgramPage() {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
 

--- a/src/app/admin/offer-shop/page.tsx
+++ b/src/app/admin/offer-shop/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
@@ -31,7 +31,7 @@ export default function OfferShopPage() {
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
 
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {

--- a/src/app/admin/program-store/page.tsx
+++ b/src/app/admin/program-store/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
@@ -34,7 +34,7 @@ export default function ProgramStorePage() {
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
 
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {

--- a/src/app/admin/slider/page.tsx
+++ b/src/app/admin/slider/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import ImageUploader from "@/app/admin/components/ImageUploader";
@@ -25,7 +25,7 @@ const sliderDoubleOptions = [
 ];
 
 export default function AdminSliderPage() {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   const [loading, setLoading] = useState(true);
   const [type, setType] = useState("none");


### PR DESCRIPTION
## Summary
- memoize the Supabase client in admin list pages to keep a stable reference across renders
- update admin forms and utilities to reuse a shared Supabase client instance
- ensure callbacks depend only on stable Supabase instances to avoid needless refresh loops

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da66fbc1ac832e9f6167481c986965