### PR TITLE
Handle nullable search params in onboarding pages

### DIFF
--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -44,7 +44,8 @@ const InformationsPage = () => {
   const supabase = createClientComponentClient();
   const { submit, loading: hookLoading, error: hookError } = useProfileSubmit();
 
-  const plan = parsePlan(searchParams.get("plan"));
+  const planParam = searchParams?.get("plan") ?? null;
+  const plan = parsePlan(planParam);
   const stepMetadata = plan ? getStepMetadata(plan, "profile") : null;
 
   const [gender, setGender] = useState("");

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -16,7 +16,8 @@ const AccountCreationPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const plan = parsePlan(searchParams.get("plan"));
+  const planParam = searchParams?.get("plan") ?? null;
+  const plan = parsePlan(planParam);
   const stepMetadata = getStepMetadata(plan, "account");
 
   const [accepted, setAccepted] = useState(false);
@@ -57,7 +58,7 @@ const AccountCreationPage = () => {
 
   const isFormValid = accepted && isPrenomFieldValid && isEmailValidFormat && isPasswordValidFormat && !loading;
 
-  const searchParamsString = searchParams.toString();
+  const searchParamsString = searchParams?.toString() ?? "";
 
   const nextStepPath = useMemo(() => {
     if (!plan) {

--- a/src/app/inscription/paiement/page.tsx
+++ b/src/app/inscription/paiement/page.tsx
@@ -20,28 +20,31 @@ const PaymentPage = () => {
   const pathname = usePathname() ?? "/inscription/paiement";
   const searchParams = useSearchParams();
 
-  const plan = parsePlan(searchParams.get("plan"));
+  const planParam = searchParams?.get("plan") ?? null;
+  const plan = parsePlan(planParam);
   const stepMetadata = plan ? getStepMetadata(plan, "payment") : null;
 
   const [loading, setLoading] = useState(false);
   const [accepted, setAccepted] = useState(false);
 
+  const trialEndParam = searchParams?.get("trialEnd") ?? null;
+
   const trialEndLabel = useMemo(() => {
-    const explicit = searchParams.get("trialEnd");
+    const explicit = trialEndParam;
     if (explicit) return explicit;
 
     const now = new Date();
     now.setDate(now.getDate() + 14);
     return formatFr(now);
-  }, [searchParams]);
+  }, [trialEndParam]);
 
-  const priceLabel = searchParams.get("price") ?? "2,49 €/mois";
+  const priceLabel = searchParams?.get("price") ?? "2,49 €/mois";
 
   const handleContinue = async () => {
     if (!accepted) return;
     setLoading(true);
     try {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
       const destination = nextStepPath(pathname, params);
       router.push(destination);
     } finally {


### PR DESCRIPTION
## Summary
- guard onboarding pages against null searchParams before reading query values
- reuse derived query string data when building next step URLs
- ensure payment trial end and price labels fall back safely when parameters are absent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da689232f0832ea323714dcf8a26f0