### PR TITLE
Refactor bespoke modals to use shared UI components

### DIFF
--- a/src/components/DownloadAuthModal.tsx
+++ b/src/components/DownloadAuthModal.tsx
@@ -1,8 +1,7 @@
-import Image from "next/image";
-import { useState } from "react";
-import ReactDOM from "react-dom";
 import { useRouter } from "next/navigation";
 import CTAButton from "@/components/CTAButton";
+import Modal from "@/components/ui/Modal";
+import ModalMessage from "@/components/ui/ModalMessage";
 
 interface DownloadAuthModalProps {
   show: boolean;
@@ -10,44 +9,14 @@ interface DownloadAuthModalProps {
 }
 
 export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalProps) {
-  const [hoveredClose, setHoveredClose] = useState(false);
   const router = useRouter();
 
-  if (!show) return null;
-
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        <button
-          onClick={onClose}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
-
-        <h2 className="text-xl text-[#3A416F] text-[22px] font-bold mb-6 text-center">Téléchargement impossible</h2>
-
-        <div className="bg-[#F4F5FE] border-l-[3px] border-[#A1A5FD] pl-4 py-3 mb-6 text-[#7069FA] text-[12px] font-bold text-left rounded-tr-[5px] rounded-br-[5px]">
-          Attention<br />
-          <span className="font-semibold text-[12px] text-[#A1A5FD]">
-            Le téléchargement de ce programme d’entraînements est impossible car vous devez avoir préalablement créé un compte.
-          </span>
-        </div>
-
-        <p className="text-[14px] text-[#5D6494] font-semibold mb-6 text-left leading-normal">
-          En cliquant sur <span className="text-[#3A416F]">« Créer un compte »</span> vous serez redirigé vers une page où vous pourrez créer votre compte en choisissant la formule d’abonnement qui convient à votre besoin.
-          <br /><br />
-          En cliquant sur <span className="text-[#3A416F]">« Annuler »</span> vous resterez sur la page du Glift Store et vous pourrez continuer votre navigation.
-        </p>
-
+  return (
+    <Modal
+      open={show}
+      title="Téléchargement impossible"
+      onClose={onClose}
+      footer={
         <div className="flex justify-center gap-4">
           <button
             onClick={onClose}
@@ -64,8 +33,21 @@ export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalPr
             Créer un compte
           </CTAButton>
         </div>
-      </div>
-    </div>,
-    document.body
+      }
+    >
+      <ModalMessage
+        variant="info"
+        title="Attention"
+        description="Le téléchargement de ce programme d’entraînements est impossible car vous devez avoir préalablement créé un compte."
+        className="mb-6"
+      />
+
+      <p className="text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+        En cliquant sur <span className="text-[#3A416F]">« Créer un compte »</span> vous serez redirigé vers une page où vous pourrez créer votre compte en choisissant la formule d’abonnement qui convient à votre besoin.
+        <br />
+        <br />
+        En cliquant sur <span className="text-[#3A416F]">« Annuler »</span> vous resterez sur la page du Glift Store et vous pourrez continuer votre navigation.
+      </p>
+    </Modal>
   );
 }

--- a/src/components/LinkModal.tsx
+++ b/src/components/LinkModal.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import CTAButton from "@/components/CTAButton";
+import Modal from "@/components/ui/Modal";
 
 interface LinkModalProps {
   exercice: string;
@@ -13,7 +12,6 @@ interface LinkModalProps {
 export default function LinkModal({ exercice, initialLink = "", onCancel, onSave }: LinkModalProps) {
   const [link, setLink] = useState(initialLink);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [hoveredClose, setHoveredClose] = useState(false);
   const [exerciceInput, setExercice] = useState(exercice);
 
   useEffect(() => {
@@ -31,49 +29,14 @@ export default function LinkModal({ exercice, initialLink = "", onCancel, onSave
     }
   };
 
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        {/* Bouton de fermeture */}
-        <button
-          onClick={onCancel}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
+  const title = initialLink.trim() ? "Modifier le lien" : "Ajouter un lien";
 
-        <h2 className="text-xl text-[#3A416F] text-[22px] font-bold mb-4 text-center">{initialLink.trim() ? "Modifier le lien" : "Ajouter un lien"}</h2>
-
-        <div className="mb-4">
-          <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Exercice</label>
-            <input
-            type="text"
-            value={exerciceInput}
-            onChange={(e) => setExercice(e.target.value)}
-            className="h-[45px] w-full text-[16px] font-semibold px-[15px] rounded-[5px] bg-white text-[#5D6494] border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-            />
-        </div>
-
-        <div className="mb-6">
-          <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Lien</label>
-          <input
-            ref={inputRef}
-            type="text"
-            value={link}
-            onChange={(e) => setLink(e.target.value)}
-            placeholder="Insérez votre lien ici"
-            className="h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-          />
-        </div>
-
+  return (
+    <Modal
+      open
+      title={title}
+      onClose={onCancel}
+      footer={
         <div className="flex justify-center gap-3">
           {initialLink ? (
             <button
@@ -104,8 +67,29 @@ export default function LinkModal({ exercice, initialLink = "", onCancel, onSave
             Enregistrer
           </CTAButton>
         </div>
+      }
+    >
+      <div className="mb-4">
+        <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Exercice</label>
+        <input
+          type="text"
+          value={exerciceInput}
+          onChange={(e) => setExercice(e.target.value)}
+          className="h-[45px] w-full rounded-[5px] border border-[#D7D4DC] px-[15px] text-[16px] font-semibold text-[#5D6494] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+        />
       </div>
-    </div>,
-    document.body
+
+      <div className="mb-6">
+        <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Lien</label>
+        <input
+          ref={inputRef}
+          type="text"
+          value={link}
+          onChange={(e) => setLink(e.target.value)}
+          placeholder="Insérez votre lien ici"
+          className="h-[45px] w-full rounded-[5px] border border-[#D7D4DC] px-[15px] text-[16px] font-semibold text-[#5D6494] transition-all duration-150 placeholder-[#D7D4DC] hover:border-[#C2BFC6] focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+        />
+      </div>
+    </Modal>
   );
 }

--- a/src/components/NoteModal.tsx
+++ b/src/components/NoteModal.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import CTAButton from "@/components/CTAButton";
+import Modal from "@/components/ui/Modal";
 
 interface NoteModalProps {
   initialNote: string;
@@ -12,7 +11,6 @@ interface NoteModalProps {
 export default function NoteModal({ initialNote = "", onCancel, onSave }: NoteModalProps) {
   const [note, setNote] = useState(initialNote);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [hoveredClose, setHoveredClose] = useState(false);
 
   useEffect(() => {
     setTimeout(() => {
@@ -20,39 +18,14 @@ export default function NoteModal({ initialNote = "", onCancel, onSave }: NoteMo
     }, 0);
   }, []);
 
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        {/* Bouton de fermeture */}
-        <button
-          onClick={onCancel}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
+  const title = initialNote.trim() ? "Modifier la note" : "Ajouter une note";
 
-        <h2 className="text-xl text-[#3A416F] text-[22px] font-bold mb-4 text-center">{initialNote.trim() ? "Modifier la note" : "Ajouter une note"}</h2>
-
-        <div className="mb-6">
-          <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Note</label>
-          <textarea
-            ref={textareaRef}
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="Ajoutez votre note ici"
-            rows={4}
-            className="w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] py-[12px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD] resize-none"
-          />
-        </div>
-
+  return (
+    <Modal
+      open
+      title={title}
+      onClose={onCancel}
+      footer={
         <div className="flex justify-center gap-3">
           {initialNote ? (
             <button
@@ -73,8 +46,19 @@ export default function NoteModal({ initialNote = "", onCancel, onSave }: NoteMo
             Enregistrer
           </CTAButton>
         </div>
+      }
+    >
+      <div className="mb-6">
+        <label className="text-[16px] text-[#3A416F] font-bold mb-[5px] block">Note</label>
+        <textarea
+          ref={textareaRef}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Ajoutez votre note ici"
+          rows={4}
+          className="w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] py-[12px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD] resize-none"
+        />
       </div>
-    </div>,
-    document.body
+    </Modal>
   );
 }

--- a/src/components/OfferCodeModal.tsx
+++ b/src/components/OfferCodeModal.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import { useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import Tooltip from "@/components/Tooltip";
 import CTAButton from "@/components/CTAButton";
+import Modal from "@/components/ui/Modal";
 
 interface OfferModalProps {
   name: string;
@@ -30,7 +30,6 @@ export default function OfferModal({
   onConfirm,
 }: OfferModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [hoveredClose, setHoveredClose] = useState(false);
   const [hoveredCopy, setHoveredCopy] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -65,121 +64,14 @@ export default function OfferModal({
     ?.replace(/\{date\}/gi, formatDate(endDate))
     ?.replace(/\{site\}/gi, cleanedSite);
 
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        {/* Fermer */}
-        <button
-          onClick={onCancel}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
-
-        {/* Logo partenaire */}
-        {brandImage && (
-          <div className="flex justify-center mt-4 mb-4">
-            <div className="w-[70px] h-[70px] rounded-full border-[3px] border-white bg-white overflow-hidden shadow-[0_0_10px_rgba(93,100,148,0.25)] relative">
-              <Image
-                src={brandImage}
-                alt="Partenaire"
-                fill
-                sizes="100%"
-                className="object-cover"
-                unoptimized
-              />
-            </div>
-          </div>
-        )}
-
-        {/* Titre */}
-        <h2 className="text-center text-[18px] text-[#3A416F] font-bold mt-5 mb-5 uppercase">
-          {name}
-        </h2>
-
-        {/* Texte explicatif */}
-        <div className="text-left text-[#3A416F] mb-3">
-          <h3 className="text-[14px] font-bold mb-1">
-            Comment profiter de cette offre ?
-          </h3>
-          {modal === "Avec code" ? (
-            <p className="font-semibold text-[14px] text-[#5D6494]">
-              Pour profiter immédiatement de cette offre, copiez le code de
-              réduction ci-dessous et collez-le dans votre panier.
-            </p>
-          ) : (
-            <p className="font-semibold text-[14px] text-[#5D6494]">
-              Aucun code n&apos;est nécessaire pour profiter de cette offre. Cliquez
-              sur le bouton ci-dessous pour être automatiquement redirigé vers le site
-              partenaire.
-            </p>
-          )}
-        </div>
-
-        {/* Zone code + bouton copie */}
-        {modal === "Avec code" && code && (
-          <div className="flex justify-center mb-6 relative w-[300px] mx-auto mt-6">
-            <input
-              ref={inputRef}
-              value={code}
-              readOnly
-              className="w-full h-[45px] text-center text-[16px] font-bold px-[15px] pr-[40px] rounded-[5px] bg-white text-[#5D6494]
-                         border border-[#D7D4DC] hover:border-[#C2BFC6]
-                         focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]
-                         transition-all duration-150 select-none cursor-default"
-            />
-            <div className="absolute right-2 top-1/2 -translate-y-1/2">
-              <Tooltip
-                content="Copié !"
-                delay={0}
-                forceVisible={copied}
-                disableHover
-              >
-                <button
-                  onClick={handleCopy}
-                  onMouseEnter={() => setHoveredCopy(true)}
-                  onMouseLeave={() => setHoveredCopy(false)}
-                  className="p-1 transition mt-[6px]"
-                  title="Copier"
-                >
-                  <Image
-                    src={
-                      copied
-                        ? "/icons/check.svg"
-                        : hoveredCopy
-                        ? "/icons/copy_hover.svg"
-                        : "/icons/copy.svg"
-                    }
-                    alt="Copier"
-                    width={20}
-                    height={20}
-                    className="w-5 h-5"
-                  />
-                </button>
-              </Tooltip>
-            </div>
-          </div>
-        )}
-
-        {/* Bloc "Conditions de l'offre" */}
-        {parsedCondition && (
-          <div className="text-left text-[#3A416F] mb-6">
-            <h3 className="text-[14px] font-bold mb-1">Conditions de l&apos;offre</h3>
-            <p className="font-semibold text-[14px] text-[#5D6494]">
-              {parsedCondition}
-            </p>
-          </div>
-        )}
-
-        {/* Boutons */}
+  return (
+    <Modal
+      open
+      title={name}
+      onClose={onCancel}
+      titleClassName="order-2 mt-5 mb-5 text-center text-[18px] font-bold uppercase"
+      contentClassName="flex flex-col items-center"
+      footer={
         <div className="flex justify-center gap-3">
           <button
             onClick={onCancel}
@@ -200,13 +92,87 @@ export default function OfferModal({
                 alt="→"
                 width={25}
                 height={25}
-                className="w-[25px] h-[25px]"
+                className="h-[25px] w-[25px]"
               />
             </span>
           </CTAButton>
         </div>
+      }
+    >
+      {brandImage && (
+        <div className="order-1 mb-4 mt-4 flex justify-center">
+          <div className="relative h-[70px] w-[70px] overflow-hidden rounded-full border-[3px] border-white bg-white shadow-[0_0_10px_rgba(93,100,148,0.25)]">
+            <Image
+              src={brandImage}
+              alt="Partenaire"
+              fill
+              sizes="100%"
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="order-3 mb-3 w-full text-left text-[#3A416F]">
+        <h3 className="mb-1 text-[14px] font-bold">Comment profiter de cette offre ?</h3>
+        {modal === "Avec code" ? (
+          <p className="text-[14px] font-semibold text-[#5D6494]">
+            Pour profiter immédiatement de cette offre, copiez le code de réduction ci-dessous et collez-le dans votre panier.
+          </p>
+        ) : (
+          <p className="text-[14px] font-semibold text-[#5D6494]">
+            Aucun code n&apos;est nécessaire pour profiter de cette offre. Cliquez sur le bouton ci-dessous pour être automatiquement redirigé vers le site partenaire.
+          </p>
+        )}
       </div>
-    </div>,
-    document.body
+
+      {modal === "Avec code" && code && (
+        <div className="order-4 mt-6 mb-6 flex w-[300px] justify-center">
+          <div className="relative w-full">
+            <input
+              ref={inputRef}
+              value={code}
+              readOnly
+              className="h-[45px] w-full cursor-default select-none rounded-[5px] border border-[#D7D4DC] px-[15px] pr-[40px] text-center text-[16px] font-bold text-[#5D6494] transition-all duration-150 hover:border-[#C2BFC6] focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#A1A5FD]"
+            />
+            <div className="absolute right-2 top-1/2 -translate-y-1/2">
+              <Tooltip content="Copié !" delay={0} forceVisible={copied} disableHover>
+                <button
+                  onClick={handleCopy}
+                  onMouseEnter={() => setHoveredCopy(true)}
+                  onMouseLeave={() => setHoveredCopy(false)}
+                  className="mt-[6px] p-1 transition"
+                  title="Copier"
+                >
+                  <Image
+                    src={
+                      copied
+                        ? "/icons/check.svg"
+                        : hoveredCopy
+                        ? "/icons/copy_hover.svg"
+                        : "/icons/copy.svg"
+                    }
+                    alt="Copier"
+                    width={20}
+                    height={20}
+                    className="h-5 w-5"
+                  />
+                </button>
+              </Tooltip>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {parsedCondition && (
+        <div className="order-5 mb-6 w-full text-left text-[#3A416F]">
+          <h3 className="mb-1 text-[14px] font-bold">Conditions de l&apos;offre</h3>
+          <p className="text-[14px] font-semibold text-[#5D6494]">
+            {parsedCondition}
+          </p>
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/src/components/PremiumOnlyModal.tsx
+++ b/src/components/PremiumOnlyModal.tsx
@@ -1,53 +1,22 @@
-import Image from "next/image";
-import { useState } from "react";
-import ReactDOM from "react-dom";
 import { useRouter } from "next/navigation";
 import CTAButton from "@/components/CTAButton";
+import Modal from "@/components/ui/Modal";
+import ModalMessage from "@/components/ui/ModalMessage";
 
-interface DownloadAuthModalProps {
+interface PremiumOnlyModalProps {
   show: boolean;
   onClose: () => void;
 }
 
-export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalProps) {
-  const [hoveredClose, setHoveredClose] = useState(false);
+export default function PremiumOnlyModal({ show, onClose }: PremiumOnlyModalProps) {
   const router = useRouter();
 
-  if (!show) return null;
-
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        <button
-          onClick={onClose}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
-
-        <h2 className="text-xl text-[#3A416F] text-[22px] font-bold mb-6 text-center">Offre bloquée</h2>
-
-        <div className="bg-[#F4F5FE] border-l-[3px] border-[#A1A5FD] pl-4 py-3 mb-6 text-[#7069FA] text-[12px] font-bold text-left rounded-tr-[5px] rounded-br-[5px]">
-          Attention<br />
-          <span className="font-semibold text-[12px] text-[#A1A5FD]">
-            Cette offre est bloquée car votre abonnement actuelle ne vous permet pas de profiter des offres réservées aux membres Premium.
-          </span>
-        </div>
-
-        <p className="text-[14px] text-[#5D6494] font-semibold mb-6 text-left leading-normal">
-          En cliquant sur <span className="text-[#3A416F]">« Débloquer »</span> vous serez redirigé vers votre compte où vous pourrez souscrire à la formule d’abonnement Premium qui vous donnera accès aux offres bloquées.
-          <br /><br />
-          En cliquant sur <span className="text-[#3A416F]">« Annuler »</span> aucun changement ne sera appliqué à votre formule d’abonnement et vous pourrez continuer à profiter gratuitement de toutes les offres à l’exception des offres <span className="text-[#3A416F]">Premium</span>.
-        </p>
-
+  return (
+    <Modal
+      open={show}
+      title="Offre bloquée"
+      onClose={onClose}
+      footer={
         <div className="flex justify-center gap-4">
           <button
             onClick={onClose}
@@ -64,8 +33,21 @@ export default function DownloadAuthModal({ show, onClose }: DownloadAuthModalPr
             Débloquer
           </CTAButton>
         </div>
-      </div>
-    </div>,
-    document.body
+      }
+    >
+      <ModalMessage
+        variant="info"
+        title="Attention"
+        description="Cette offre est bloquée car votre abonnement actuelle ne vous permet pas de profiter des offres réservées aux membres Premium."
+        className="mb-6"
+      />
+
+      <p className="text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+        En cliquant sur <span className="text-[#3A416F]">« Débloquer »</span> vous serez redirigé vers votre compte où vous pourrez souscrire à la formule d’abonnement Premium qui vous donnera accès aux offres bloquées.
+        <br />
+        <br />
+        En cliquant sur <span className="text-[#3A416F]">« Annuler »</span> aucun changement ne sera appliqué à votre formule d’abonnement et vous pourrez continuer à profiter gratuitement de toutes les offres à l’exception des offres <span className="text-[#3A416F]">Premium</span>.
+      </p>
+    </Modal>
   );
 }

--- a/src/components/ProgramDeleteModal.tsx
+++ b/src/components/ProgramDeleteModal.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
-import { useState } from "react";
-import ReactDOM from "react-dom";
+import Modal from "@/components/ui/Modal";
+import ModalMessage from "@/components/ui/ModalMessage";
 
 interface ProgramDeleteModalProps {
   show: boolean;
@@ -9,48 +8,12 @@ interface ProgramDeleteModalProps {
 }
 
 export default function ProgramDeleteModal({ show, onCancel, onConfirm }: ProgramDeleteModalProps) {
-  const [hoveredClose, setHoveredClose] = useState(false);
-
-  if (!show) return null;
-
-  return ReactDOM.createPortal(
-    <div className="fixed inset-0 bg-[#2E3142] bg-opacity-60 z-50 flex items-center justify-center">
-      <div className="relative bg-white p-8 rounded-[5px] w-[564px] shadow-lg">
-        {/* Bouton de fermeture */}
-        <button
-          onClick={onCancel}
-          onMouseEnter={() => setHoveredClose(true)}
-          onMouseLeave={() => setHoveredClose(false)}
-          className="absolute top-4 right-4 w-6 h-6"
-        >
-          <Image
-            src={hoveredClose ? "/icons/close_hover.svg" : "/icons/close.svg"}
-            alt="Fermer"
-            width={24}
-            height={24}
-            className="w-full h-full"
-          />
-        </button>
-
-        <h2 className="text-xl text-[#3A416F] text-[22px] font-bold mb-6 text-center">Supprimer un programme</h2>
-
-        {/* Alerte avec bordure gauche */}
-        <div className="bg-[#FFE3E3] border-l-[3px] border-[#EF4F4E] pl-4 py-3 mb-6 text-[#BA2524] text-[12px] font-bold text-left rounded-tr-[5px] rounded-br-[5px]">
-          Attention<br />
-          <span className="font-semibold text-[12px] text-[#EF4F4E]">
-            La suppression d&apos;un programme d&apos;entraînements est définitive.
-          </span>
-        </div>
-
-        {/* Texte explicatif */}
-        <p className="text-[14px] text-[#5D6494] font-semibold mb-4 text-left leading-normal">
-          En cliquant sur <span className="text-[#3A416F]">« Confirmer »</span> ce programme d’entraînements ainsi que l’ensemble des exercices encore à l’intérieur seront <span className="text-[#3A416F]">définitivement supprimés</span> de la plateforme et toute progression sera perdue.
-        </p>
-        <p className="text-[14px] text-[#5D6494] font-semibold mb-6 text-left leading-normal">
-          Si ce n’est pas ce que vous souhaitez faire, vous trouverez peut-être la solution à votre besoin dans la partie <a href="#" className="text-[#3A416F] underline">Aide</a> du site.
-        </p>
-
-        {/* Boutons */}
+  return (
+    <Modal
+      open={show}
+      title="Supprimer un programme"
+      onClose={onCancel}
+      footer={
         <div className="flex justify-center gap-4">
           <button
             onClick={onCancel}
@@ -60,13 +23,26 @@ export default function ProgramDeleteModal({ show, onCancel, onConfirm }: Progra
           </button>
           <button
             onClick={onConfirm}
-            className="inline-flex items-center justify-center gap-1 w-[116px] h-[44px] bg-[#EF4F4E] hover:bg-[#BA2524] text-white font-semibold rounded-full transition-all duration-300 group"
+            className="inline-flex h-[44px] w-[116px] items-center justify-center gap-1 rounded-full bg-[#EF4F4E] font-semibold text-white transition-all duration-300 hover:bg-[#BA2524]"
           >
             Confirmer
           </button>
         </div>
-      </div>
-    </div>,
-    document.body
+      }
+    >
+      <ModalMessage
+        variant="warning"
+        title="Attention"
+        description="La suppression d&apos;un programme d&apos;entraînements est définitive."
+        className="mb-6"
+      />
+
+      <p className="text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+        En cliquant sur <span className="text-[#3A416F]">« Confirmer »</span> ce programme d’entraînements ainsi que l’ensemble des exercices encore à l’intérieur seront <span className="text-[#3A416F]">définitivement supprimés</span> de la plateforme et toute progression sera perdue.
+      </p>
+      <p className="mb-6 text-left text-[14px] font-semibold leading-normal text-[#5D6494]">
+        Si ce n’est pas ce que vous souhaitez faire, vous trouverez peut-être la solution à votre besoin dans la partie <a href="#" className="text-[#3A416F] underline">Aide</a> du site.
+      </p>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- replace custom portal implementations in the various modals with the shared `Modal` UI component
- reuse the `ModalMessage` banner for consistent information and warning messaging across modals
- adjust modal layouts and footers to preserve existing behaviors while leveraging the shared UI building blocks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da73024428832eae3b462f072514c4