### PR TITLE
Add spinner to login CTA and delay header until authentication ready

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import { IconCheckbox } from "@/components/ui/IconCheckbox";
+import Spinner from "@/components/ui/Spinner";
 
 export default function ConnexionPage() {
   const [email, setEmail] = useState("");
@@ -163,12 +164,18 @@ export default function ConnexionPage() {
               type="submit"
               disabled={!isFormValid || loading}
               className={`w-full max-w-[160px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2
-                ${isFormValid && !loading
-                  ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
-                  : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"}`}
+                ${isFormValid ? "bg-[#7069FA] text-white" : "bg-[#ECE9F1] text-[#D7D4DC]"}
+                ${isFormValid && !loading ? "hover:bg-[#6660E4] cursor-pointer" : "cursor-not-allowed"}`}
             >
               {loading ? (
-                <span className="text-[15px]">En cours...</span>
+                <span className="inline-flex items-center gap-2 text-[15px]">
+                  <Spinner
+                    size="sm"
+                    className="text-white"
+                    ariaLabel="Connexion en cours"
+                  />
+                  En cours
+                </span>
               ) : (
                 <>
                   <Image

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,10 +11,11 @@ import CTAButton from "@/components/CTAButton";
 export default function Header() {
   const pathname = usePathname();
   const supabase = createClientComponentClient();
-  const { user, isAuthenticated } = useUser();
+  const { user, isAuthenticated, isLoading } = useUser();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const showAuthenticatedUI = isAuthenticated && !isLoading;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -48,7 +49,7 @@ export default function Header() {
       <div className="max-w-[1152px] mx-auto py-4 flex items-center justify-between md:px-0 relative">
         {/* Logo */}
         <div className="w-[147px] flex items-center">
-          <Link href={isAuthenticated ? "/dashboard" : "/"} className="flex items-center">
+          <Link href={showAuthenticatedUI ? "/dashboard" : "/"} className="flex items-center">
             <Image
               src="/logo_beta.svg"
               alt="Logo Glift"
@@ -61,7 +62,7 @@ export default function Header() {
 
         {/* Menu centré */}
         <nav className="hidden md:flex gap-6 text-[16px] text-[#5D6494] font-semibold h-[44px] items-center absolute left-1/2 transform -translate-x-1/2">
-          {isAuthenticated ? (
+          {showAuthenticatedUI ? (
             <>
               <Link
                 href="/dashboard"
@@ -200,7 +201,7 @@ export default function Header() {
 
         {/* User Zone */}
         <div className="relative ml-[18px]" ref={dropdownRef}>
-          {isAuthenticated ? (
+          {showAuthenticatedUI ? (
             <button
               onClick={() => setDropdownOpen(!dropdownOpen)}
               className="group flex items-center gap-2 text-[#5D6494] hover:text-[#3A416F] text-[16px] font-semibold"

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import { User } from "@supabase/supabase-js";
 
@@ -19,34 +25,47 @@ interface UserContextType {
   user: CustomUser | null;
   isAuthenticated: boolean;
   isPremiumUser: boolean;
+  isLoading: boolean;
 }
 
 const UserContext = createContext<UserContextType>({
   user: null,
   isAuthenticated: false,
   isPremiumUser: false,
+  isLoading: true,
 });
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
   const supabase = createClientComponentClient();
   const [user, setUser] = useState<CustomUser | null>(null);
   const [isPremiumUser, setIsPremiumUser] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    const fetchUser = async () => {
+  const fetchUser = useCallback(async () => {
+    setIsLoading(true);
+    try {
       const {
         data: { user },
+        error,
       } = await supabase.auth.getUser();
+
+      if (error) {
+        throw error;
+      }
 
       if (user) {
         const customUser = user as CustomUser;
         setUser(customUser);
 
-        const { data } = await supabase
+        const { data, error: subscriptionError } = await supabase
           .from("user_subscriptions")
           .select("plan")
           .eq("user_id", customUser.id)
           .single();
+
+        if (subscriptionError && subscriptionError.code !== "PGRST116") {
+          throw subscriptionError;
+        }
 
         const planFromSubscription = data?.plan;
         const planFromMetadata = customUser.user_metadata?.subscription_plan;
@@ -61,25 +80,34 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         setUser(null);
         setIsPremiumUser(false);
       }
-    };
+    } catch (error) {
+      console.error("Erreur lors de la récupération de l'utilisateur", error);
+      setUser(null);
+      setIsPremiumUser(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [supabase]);
 
-    fetchUser();
+  useEffect(() => {
+    void fetchUser();
 
     const { data: authListener } = supabase.auth.onAuthStateChange(() => {
-      fetchUser();
+      void fetchUser();
     });
 
     return () => {
       authListener?.subscription.unsubscribe();
     };
-  }, [supabase]);
+  }, [fetchUser, supabase]);
 
   return (
     <UserContext.Provider
       value={{
         user,
-        isAuthenticated: !!user,
+        isAuthenticated: !!user && !isLoading,
         isPremiumUser,
+        isLoading,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add a visual loading spinner to the /connexion CTA while the login request is pending
- gate the authenticated header against a new loading state so it only appears after Supabase finishes fetching the session
- extend the user context with loading management and resilient error handling during user fetches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd58ea69f8832e988cacc8926329b2