### PR TITLE
Adjust login loading spinner and preserve header auth state

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -69,6 +69,12 @@ export default function ConnexionPage() {
     }
   };
 
+  const buttonStateClasses = loading
+    ? "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
+    : isFormValid
+      ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
+      : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed";
+
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
       <div className="w-full max-w-md flex flex-col items-center px-4 sm:px-0">
@@ -163,17 +169,11 @@ export default function ConnexionPage() {
             <button
               type="submit"
               disabled={!isFormValid || loading}
-              className={`w-full max-w-[160px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2
-                ${isFormValid ? "bg-[#7069FA] text-white" : "bg-[#ECE9F1] text-[#D7D4DC]"}
-                ${isFormValid && !loading ? "hover:bg-[#6660E4] cursor-pointer" : "cursor-not-allowed"}`}
+              className={`w-full max-w-[160px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2 ${buttonStateClasses}`}
             >
               {loading ? (
                 <span className="inline-flex items-center gap-2 text-[15px]">
-                  <Spinner
-                    size="sm"
-                    className="text-white"
-                    ariaLabel="Connexion en cours"
-                  />
+                  <Spinner size="md" ariaLabel="Connexion en cours" />
                   En cours
                 </span>
               ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,11 +11,11 @@ import CTAButton from "@/components/CTAButton";
 export default function Header() {
   const pathname = usePathname();
   const supabase = createClientComponentClient();
-  const { user, isAuthenticated, isLoading } = useUser();
+  const { user, isAuthenticated } = useUser();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const showAuthenticatedUI = isAuthenticated && !isLoading;
+  const showAuthenticatedUI = isAuthenticated;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -115,7 +115,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     <UserContext.Provider
       value={{
         user,
-        isAuthenticated: !!user && !isLoading,
+        isAuthenticated: Boolean(user),
         isPremiumUser,
         isLoading,
       }}


### PR DESCRIPTION
## Summary
- align the login button loading state with the shared spinner component and disabled styling
- keep the header in its authenticated variant while auth data refreshes to avoid flicker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd5f145ec0832ea37d32da43c896ac