### PR TITLE
Améliore la gestion des erreurs sur la page de connexion

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -74,6 +74,8 @@ export default function ConnexionPage() {
         setError({
           type: "generic",
           title: "Une erreur est survenue.",
+          description:
+            "Nous n'avons pas réussi à vous connecter. Rechargez la page ou réessayez dans quelques instants.",
         });
       }
     } catch (unknownError) {
@@ -81,6 +83,8 @@ export default function ConnexionPage() {
       setError({
         type: "generic",
         title: "Une erreur est survenue.",
+        description:
+          "Nous n'avons pas réussi à vous connecter. Rechargez la page ou réessayez dans quelques instants.",
       });
     } finally {
       setLoading(false);
@@ -101,7 +105,7 @@ export default function ConnexionPage() {
         </h1>
 
         <form className="flex flex-col w-full gap-6" onSubmit={handleLogin}>
-          {error ? (
+          {error && error.type !== "invalid-email" ? (
             <ErrorMessage title={error.title} description={error.description} />
           ) : null}
 
@@ -146,6 +150,11 @@ export default function ConnexionPage() {
                     : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
                 }`}
               />
+              {showEmailFieldError ? (
+                <p className="mt-2 text-[13px] font-semibold text-[#EF4444]">
+                  Format d’adresse invalide
+                </p>
+              ) : null}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- ajoute une description détaillée pour l'erreur générique de connexion
- affiche l'erreur de format d'adresse directement sous le champ email et évite la bannière globale

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8e1a1910832e99366bc8ecc2ff72