### PR TITLE
Fix login email field error handling

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -34,7 +34,7 @@ export default function ConnexionPage() {
   const shouldShowEmailError =
     emailTouched && !emailFocused && email.trim() !== "" && !isEmailValidFormat;
   const showEmailFieldError =
-    shouldShowEmailError || error?.type === "invalid-email";
+    !emailFocused && (shouldShowEmailError || error?.type === "invalid-email");
 
   const isFormValid = email.trim() !== "" && password.trim() !== "";
 
@@ -151,7 +151,7 @@ export default function ConnexionPage() {
                 }`}
               />
               {showEmailFieldError ? (
-                <p className="mt-2 text-[13px] font-semibold text-[#EF4444]">
+                <p className="mt-2 text-[13px] font-medium text-[#EF4444]">
                   Format d’adresse invalide
                 </p>
               ) : null}


### PR DESCRIPTION
## Summary
- align the login email field error state with the signup page by clearing the visual error when the field is focused
- update the login email error message typography to use the requested medium font weight

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de1912aa04832e923d00b69288dc0e