### PR TITLE
Adjust connexion email feedback and spacing

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -103,49 +103,52 @@ export default function ConnexionPage() {
             <ErrorMessage title={error.title} description={error.description} />
           ) : null}
 
-          {/* Email */}
-          <div className="w-full flex justify-center">
-            <EmailField
-              id="email"
-              label="Email"
-              value={email}
-              onChange={(nextEmail) => {
-                setEmail(nextEmail);
-                if (error?.type === "invalid-email") {
-                  setError(null);
-                }
-              }}
-              externalError={error?.type === "invalid-email" ? error.title : null}
-              containerClassName="w-full max-w-[368px]"
-              messageContainerClassName="mt-2 text-[13px] font-medium"
-              autoComplete="email"
-            />
-          </div>
+          <div className="flex flex-col gap-0">
+            {/* Email */}
+            <div className="w-full flex justify-center">
+              <EmailField
+                id="email"
+                label="Email"
+                value={email}
+                onChange={(nextEmail) => {
+                  setEmail(nextEmail);
+                  if (error?.type === "invalid-email") {
+                    setError(null);
+                  }
+                }}
+                externalError={error?.type === "invalid-email" ? error.title : null}
+                containerClassName="w-full max-w-[368px]"
+                messageContainerClassName="mt-2 text-[13px] font-medium"
+                hideSuccessMessage
+                autoComplete="email"
+              />
+            </div>
 
-          {/* Mot de passe */}
-          <div className="w-full flex justify-center">
-            <PasswordField
-              id="password"
-              value={password}
-              onChange={(nextPassword) => {
-                setPassword(nextPassword);
-                if (error && error.type !== "invalid-email") {
-                  setError(null);
+            {/* Mot de passe */}
+            <div className="w-full flex justify-center">
+              <PasswordField
+                id="password"
+                value={password}
+                onChange={(nextPassword) => {
+                  setPassword(nextPassword);
+                  if (error && error.type !== "invalid-email") {
+                    setError(null);
+                  }
+                }}
+                label="Mot de passe"
+                labelAction={
+                  <Link
+                    href="/mot-de-passe-oublie"
+                    className="text-[#7069FA] text-[10px] pt-[6px] font-medium hover:text-[#6660E4]"
+                  >
+                    Mot de passe oublié ?
+                  </Link>
                 }
-              }}
-              label="Mot de passe"
-              labelAction={
-                <Link
-                  href="/mot-de-passe-oublie"
-                  className="text-[#7069FA] text-[10px] pt-[6px] font-medium hover:text-[#6660E4]"
-                >
-                  Mot de passe oublié ?
-                </Link>
-              }
-              containerClassName="w-full max-w-[368px]"
-              messageContainerClassName="mt-2 text-[13px] font-medium"
-              autoComplete="current-password"
-            />
+                containerClassName="w-full max-w-[368px]"
+                messageContainerClassName="mt-2 text-[13px] font-medium"
+                autoComplete="current-password"
+              />
+            </div>
           </div>
 
           {/* Checkbox */}

--- a/src/components/forms/EmailField.tsx
+++ b/src/components/forms/EmailField.tsx
@@ -14,6 +14,7 @@ export interface EmailFieldProps
   onChange: (value: string) => void;
   label?: string;
   successMessage?: string;
+  hideSuccessMessage?: boolean;
   errorMessage?: string;
   externalError?: string | null;
   containerClassName?: string;
@@ -29,6 +30,7 @@ export function EmailField({
   label = "Adresse e-mail",
   placeholder = "john.doe@email.com",
   successMessage = "Merci, cet email sera ton identifiant de connexion",
+  hideSuccessMessage = false,
   errorMessage = "Format d’adresse invalide",
   externalError,
   containerClassName,
@@ -44,7 +46,8 @@ export function EmailField({
   const trimmedValue = value.trim();
   const hasValue = trimmedValue !== "";
   const isValid = isValidEmail(value);
-  const showSuccess = touched && !focused && isValid && !externalError;
+  const showSuccess =
+    !hideSuccessMessage && touched && !focused && isValid && !externalError;
   const showInternalError = touched && !focused && hasValue && !isValid;
   const showExternalError = Boolean(externalError) && !focused;
   const showError = showInternalError || showExternalError;


### PR DESCRIPTION
## Summary
- add an option to hide the EmailField success feedback
- disable the success message on the connexion email field and group the credential inputs without extra gap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de2336a470832eaf3ebe3fcd24a6af