### PR TITLE
Adjust spacing around remember checkbox on login page

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -149,20 +149,19 @@ export default function ConnexionPage() {
                 autoComplete="current-password"
               />
             </div>
-          </div>
-
-          {/* Checkbox */}
-          <div className="w-full flex justify-center">
-            <div className="w-full max-w-[368px] mb-[10px]">
-              <label className="flex items-center gap-2 cursor-pointer text-[14px] font-semibold text-[#5D6494]">
-                <IconCheckbox
-                  name="remember"
-                  checked={rememberMe}
-                  onChange={(e) => setRememberMe(e.target.checked)}
-                  size={15}
-                />
-                Je veux rester connecté.
-              </label>
+            {/* Checkbox */}
+            <div className="w-full flex justify-center pt-3">
+              <div className="w-full max-w-[368px] mb-[10px]">
+                <label className="flex items-center gap-2 cursor-pointer text-[14px] font-semibold text-[#5D6494]">
+                  <IconCheckbox
+                    name="remember"
+                    checked={rememberMe}
+                    onChange={(e) => setRememberMe(e.target.checked)}
+                    size={15}
+                  />
+                  Je veux rester connecté.
+                </label>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- move the "remember me" checkbox into the password field stack to eliminate the excessive gap
- add local padding to keep a small, consistent spacing between the password field and the checkbox

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de24b51bec832eac95a1e4abf938e5