### PR TITLE
Adjust training row drag cell alignment

### DIFF
--- a/src/components/TrainingRow.tsx
+++ b/src/components/TrainingRow.tsx
@@ -107,21 +107,21 @@ export default function TrainingRow({
         className="px-0 py-0"
         style={{ maxWidth: "60px", width: "60px", backgroundColor: row.checked ? "#F4F5FE" : "transparent" }}
       >
-        <div className="flex items-center h-10 justify-start border-t border-[#ECE9F1] pl-3">
+        <div className="flex items-center h-10 justify-center gap-3 border-t border-[#ECE9F1]">
           <Image
             {...dragListeners}
             src={row.iconHovered ? "/icons/drag_hover.svg" : "/icons/drag.svg"}
             alt="Icone"
-            width={16}
-            height={16}
-            className={`w-4 h-4 mr-2 select-none ${isGrabbing ? "cursor-grabbing" : "cursor-grab"}`}
+            width={20}
+            height={20}
+            className={`w-5 h-5 select-none ${isGrabbing ? "cursor-grabbing" : "cursor-grab"}`}
             onMouseEnter={() => handleIconHover(index, true)}
             onMouseDown={() => setIsGrabbing(true)}
             onMouseLeave={() => handleIconHover(index, false)}
           />
           <button
             onClick={() => handleCheckboxChange(rowId)}
-            className="mr-2 flex items-center justify-center"
+            className="flex items-center justify-center"
             style={{ width: "15px", height: "15px" }}
           >
             <Image


### PR DESCRIPTION
## Summary
- center the drag handle and checkbox icons within the training row icon cell and space them consistently
- enlarge the drag handle icon to improve visibility while keeping the checkbox alignment intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de5e6925e4832ea6c350bcf7852aac