### PR TITLE
Reduce spacing between drag icon and checkbox in training tables

### DIFF
--- a/src/components/TrainingRow.tsx
+++ b/src/components/TrainingRow.tsx
@@ -107,7 +107,7 @@ export default function TrainingRow({
         className="px-0 py-0"
         style={{ maxWidth: "60px", width: "60px", backgroundColor: row.checked ? "#F4F5FE" : "transparent" }}
       >
-        <div className="flex items-center h-10 justify-center gap-3 border-t border-[#ECE9F1]">
+        <div className="flex items-center h-10 justify-center gap-2 border-t border-[#ECE9F1]">
           <Image
             {...dragListeners}
             src={row.iconHovered ? "/icons/drag_hover.svg" : "/icons/drag.svg"}

--- a/src/components/TrainingRowOverlay.tsx
+++ b/src/components/TrainingRowOverlay.tsx
@@ -39,7 +39,7 @@ export default function TrainingRowOverlay({ row, columns }: Props) {
             alt="Icone"
             width={16}
             height={16}
-            className="w-4 h-4 mr-2 cursor-grabbing select-none"
+            className="w-4 h-4 mr-1 cursor-grabbing select-none"
             style={{ display: "block" }}
           />
           <Image


### PR DESCRIPTION
## Summary
- decrease the gap between the drag handle and checkbox in training rows
- align the drag overlay spacing so the handle and checkbox stay close while dragging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de600a00b4832e94c26857e0368790