### PR TITLE
Handle remember-me preference for Supabase sessions

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -33,6 +33,26 @@ export default function ConnexionPage() {
   const isEmailValidFormat = isValidEmail(email);
   const isFormValid = isEmailValidFormat && password.trim() !== "";
 
+  const persistRememberPreference = (value: boolean) => {
+    const cookieName = "glift-remember";
+
+    // Supprime la valeur précédente pour éviter les attributs périmés (ex: Max-Age)
+    document.cookie = `${cookieName}=; Path=/; Max-Age=0; SameSite=Lax`;
+
+    const segments = [
+      `${cookieName}=${value ? "1" : "0"}`,
+      "Path=/",
+      "SameSite=Lax",
+    ];
+
+    if (value) {
+      // 1 an de persistance
+      segments.push(`Max-Age=${60 * 60 * 24 * 365}`);
+    }
+
+    document.cookie = segments.join("; ");
+  };
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (loading) return;
@@ -46,6 +66,7 @@ export default function ConnexionPage() {
     setLoading(true);
 
     try {
+      persistRememberPreference(rememberMe);
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,

--- a/src/app/deconnexion/page.tsx
+++ b/src/app/deconnexion/page.tsx
@@ -10,6 +10,7 @@ export default function LogoutPage() {
 
   useEffect(() => {
     const logout = async () => {
+      document.cookie = "glift-remember=; Path=/; Max-Age=0; SameSite=Lax";
       await supabase.auth.signOut();
       router.push("/");
     };


### PR DESCRIPTION
## Summary
- store the remember-me selection in a glift-remember cookie during login and clear it on sign out
- adjust Supabase server cookie handling to drop maxAge/expires when the preference disables persistence
- ensure the OAuth callback respects the preference when issuing Supabase cookies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de631faeec832e8ed6a1c9085f0878