### PR TITLE
Add middleware Supabase client honoring remember preference

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,14 @@
 "use server";
 
-import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { createRememberingMiddlewareClient } from "@/lib/supabase/middleware";
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
 
   // Crée le client Supabase middleware-compatible
-  const supabase = createMiddlewareClient({ req, res });
+  const supabase = createRememberingMiddlewareClient({ req, res });
 
   // Charge la session utilisateur côté serveur
   const {

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,0 +1,159 @@
+import {
+  CookieAuthStorageAdapter,
+  type CookieOptions,
+  type CookieOptionsWithName,
+  createSupabaseClient,
+  type DefaultCookieOptions,
+  parseCookies,
+  serializeCookie,
+  type SupabaseClientOptionsWithoutAuth,
+} from "@supabase/auth-helpers-shared";
+import authHelpersPackage from "@supabase/auth-helpers-nextjs/package.json";
+import { NextResponse } from "next/server";
+import { splitCookiesString } from "set-cookie-parser";
+
+import type { NextRequest } from "next/server";
+import type { GenericSchema } from "@supabase/supabase-js/dist/module/lib/types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const PACKAGE_NAME = authHelpersPackage.name;
+const PACKAGE_VERSION = authHelpersPackage.version;
+
+const shouldPersistSession = (req: NextRequest) => {
+  const rememberPreference = req.cookies.get("glift-remember");
+  return rememberPreference?.value !== "0";
+};
+
+const sanitizeCookieOptions = (
+  options: DefaultCookieOptions | undefined,
+  persist: boolean,
+) => {
+  if (!options || persist) {
+    return options;
+  }
+
+  if (options.maxAge === 0) {
+    return options;
+  }
+
+  const sanitized = { ...options };
+  delete sanitized.maxAge;
+  delete sanitized.expires;
+
+  return sanitized;
+};
+
+class RememberMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
+  constructor(
+    private readonly context: { req: NextRequest; res: NextResponse },
+    private readonly persistSession: boolean,
+    cookieOptions?: CookieOptions,
+  ) {
+    super(cookieOptions);
+  }
+
+  protected getCookie(name: string): string | null | undefined {
+    const setCookie = splitCookiesString(
+      this.context.res.headers.get("set-cookie")?.toString() ?? "",
+    )
+      .map((cookie) => parseCookies(cookie)[name])
+      .find((cookie) => !!cookie);
+
+    if (setCookie) {
+      return setCookie;
+    }
+
+    const cookies = parseCookies(
+      this.context.req.headers.get("cookie") ?? "",
+    );
+
+    return cookies[name];
+  }
+
+  protected setCookie(name: string, value: string): void {
+    this.setCookieWithOptions(name, value);
+  }
+
+  protected deleteCookie(name: string): void {
+    this.setCookieWithOptions(name, "", {
+      maxAge: 0,
+    });
+  }
+
+  private setCookieWithOptions(
+    name: string,
+    value: string,
+    options?: DefaultCookieOptions,
+  ) {
+    const combinedOptions: DefaultCookieOptions | undefined = {
+      ...this.cookieOptions,
+      ...options,
+      httpOnly: false,
+    };
+
+    const sanitizedOptions = sanitizeCookieOptions(
+      combinedOptions,
+      this.persistSession,
+    );
+
+    const newSession = serializeCookie(name, value, sanitizedOptions);
+
+    if (this.context.res.headers) {
+      this.context.res.headers.append("set-cookie", newSession);
+    }
+  }
+}
+
+export function createRememberingMiddlewareClient<
+  Database extends Record<string, GenericSchema> = Record<
+    string,
+    GenericSchema
+  >,
+  SchemaName extends string & keyof Database = "public" extends keyof Database
+    ? "public"
+    : Extract<keyof Database, string>,
+  Schema extends GenericSchema = Database[SchemaName],
+>(
+  context: { req: NextRequest; res: NextResponse },
+  {
+    supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL,
+    supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    options,
+    cookieOptions,
+  }: {
+    supabaseUrl?: string;
+    supabaseKey?: string;
+    options?: SupabaseClientOptionsWithoutAuth<SchemaName>;
+    cookieOptions?: CookieOptionsWithName;
+  } = {},
+): SupabaseClient<Database, SchemaName, Schema> {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      "either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!",
+    );
+  }
+
+  const persistSession = shouldPersistSession(context.req);
+
+  return createSupabaseClient<Database, SchemaName, Schema>(
+    supabaseUrl,
+    supabaseKey,
+    {
+      ...options,
+      global: {
+        ...options?.global,
+        headers: {
+          ...options?.global?.headers,
+          "X-Client-Info": `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
+        },
+      },
+      auth: {
+        storage: new RememberMiddlewareAuthStorageAdapter(
+          context,
+          persistSession,
+          cookieOptions,
+        ),
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add a Supabase middleware client that reads the `glift-remember` cookie to decide whether to persist auth cookies
- strip persistence metadata from serialized cookies when the remember preference is disabled while keeping deletions intact
- switch the Next.js middleware to the new helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec1e5712c832eb4d75c3ac6ddc220