### PR TITLE
Use cookie-bridged Supabase client in browser components

### DIFF
--- a/src/components/SupabaseProvider.tsx
+++ b/src/components/SupabaseProvider.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { createBrowserClient } from "@supabase/ssr";
+import { createClientComponentClient } from "@/lib/supabase/client";
 import { SessionContextProvider } from "@supabase/auth-helpers-react"; // 👈 encore utile côté client React
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 export default function SupabaseProvider({ children }: { children: React.ReactNode }) {
   const [supabase] = useState(() =>
-    createBrowserClient(supabaseUrl, supabaseAnonKey)
+    createClientComponentClient()
   );
 
   return (

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,1 @@
-// lib/supabaseClient.ts
-import { createBrowserClient } from '@supabase/ssr';
-
-export const createClient = () =>
-  createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+export { createClientComponentClient as createClient } from "./supabase/client";


### PR DESCRIPTION
## Summary
- replace the Supabase provider's direct browser client creation with the shared client factory that respects the glift-remember cookie bridge
- re-export the cookie-aware factory from `src/lib/supabaseClient.ts` so existing callers continue to use the bridged client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68decaa722f8832ea30d14bb379d1913