### PR TITLE
Redirect authenticated users from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,19 @@
-"use client";
-
 import Link from "next/link";
 import Image from "next/image";
 import AnimatedSection from "@/components/AnimatedSection";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
 
-export default function HeroConcept() {
+export default async function HeroConcept() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/entrainements");
+  }
+
   return (
     <>
       {/* Section principale */}

--- a/src/components/account/sections/PreferencesSection.tsx
+++ b/src/components/account/sections/PreferencesSection.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import DeleteAccountButtonWithModal from "@/components/DeleteAccountButtonWithModal"
 import AccountAccordionSection from "../AccountAccordionSection"
 
 export default function PreferencesSection() {


### PR DESCRIPTION
## Summary
- redirect signed-in users away from the home page to `/entrainements` using a server-side Supabase check
- clean up an unused import in the account preferences section to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0c1bad960832e8a55117cab4b3b16