### PR TITLE
Adjust forgot password modal layout

### DIFF
--- a/src/components/auth/ForgotPasswordModal.tsx
+++ b/src/components/auth/ForgotPasswordModal.tsx
@@ -95,6 +95,7 @@ export default function ForgotPasswordModal({
       title="Mot de passe oublié ?"
       onClose={handleClose}
       closeDisabled={loading}
+      footerWrapperClassName="mt-[30px]"
       footer={
         <div className="flex justify-center gap-4">
           <button
@@ -121,30 +122,43 @@ export default function ForgotPasswordModal({
       <form
         id="forgot-password-form"
         onSubmit={handleSubmit}
-        className="flex flex-col items-center space-y-6"
+        className="flex flex-col items-center gap-6"
       >
-        {success ? (
-          <div className="flex w-full max-w-[368px] gap-4 rounded-[5px] border-l-[6px] border-[#57AE5B] bg-[#E3F9E5] p-4">
-            <div className="space-y-2 text-left">
-              <p className="text-[16px] font-semibold text-[#207227]">Merci pour votre email</p>
-              <p className="text-[14px] leading-relaxed text-[#57AE5B]">
-                Si un compte y est associé, un email contenant un lien pour mettre à jour votre mot de passe vous a été envoyé. Ce lien est valable pendant 30 minutes.
-              </p>
-            </div>
-          </div>
-        ) : (
-          <div className="w-full max-w-[368px]">
+        <div className="w-full max-w-[504px] space-y-4">
+          {success ? (
             <ModalMessage
-              variant="info"
-              title="Réinitialiser votre mot de passe"
-              description="Renseignez l'adresse e-mail associée à votre compte pour recevoir un lien sécurisé."
+              variant="success"
+              title="Merci pour votre email"
+              description={
+                <div className="space-y-2">
+                  <p>
+                    Si un compte y est associé, un email contenant un lien pour mettre à jour votre mot de passe vous a été envoyé.
+                  </p>
+                  <p>Ce lien est valable pendant 30 minutes.</p>
+                </div>
+              }
             />
-          </div>
-        )}
+          ) : (
+            <>
+              <ModalMessage
+                variant="info"
+                title="Réinitialiser votre mot de passe"
+                description="Renseignez l'adresse e-mail associée à votre compte pour recevoir un lien sécurisé."
+              />
+              {error && (
+                <ModalMessage
+                  variant="warning"
+                  title="Une erreur est survenue"
+                  description={error}
+                />
+              )}
+            </>
+          )}
+        </div>
 
         <EmailField
           id="forgot-password-email"
-          label="Adresse e-mail"
+          label="Email"
           value={email}
           onChange={(value) => {
             setEmail(value)
@@ -152,9 +166,10 @@ export default function ForgotPasswordModal({
               setError(null)
             }
           }}
-          externalError={error}
+          hideSuccessMessage
+          errorMessage=""
           containerClassName="w-full max-w-[368px]"
-          messageContainerClassName="mt-2 text-[13px] font-medium"
+          messageContainerClassName="hidden"
           autoComplete="email"
         />
       </form>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -17,6 +17,7 @@ type ModalProps = PropsWithChildren<{
   onClose?: () => void
   closeDisabled?: boolean
   footer?: ReactNode
+  footerWrapperClassName?: string
   closeLabel?: string
   className?: string
   contentClassName?: string
@@ -30,6 +31,7 @@ export default function Modal({
   onClose,
   closeDisabled = false,
   footer,
+  footerWrapperClassName,
   closeLabel = "Fermer",
   className,
   contentClassName,
@@ -130,7 +132,9 @@ export default function Modal({
 
         {children}
 
-        {footer && <div className="mt-6">{footer}</div>}
+        {footer && (
+          <div className={clsx("mt-6", footerWrapperClassName)}>{footer}</div>
+        )}
       </div>
     </div>,
     document.body


### PR DESCRIPTION
## Summary
- align the forgot password modal messaging with the required widths and wording
- update modal footer spacing controls so the action buttons sit 30px below the form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0d4875cec832ea65f95a8ab077c2a