### PR TITLE
Allow resending reset password emails after success

### DIFF
--- a/src/components/auth/ForgotPasswordModal.tsx
+++ b/src/components/auth/ForgotPasswordModal.tsx
@@ -164,6 +164,9 @@ export default function ForgotPasswordModal({
             if (error) {
               setError(null)
             }
+            if (success) {
+              setSuccess(false)
+            }
           }}
           hideSuccessMessage
           errorMessage=""


### PR DESCRIPTION
## Summary
- reset the forgot password modal success state when the user edits their email so they can request another reset link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0d8a53c8c832e963d936b1dd84bcc