### PR TITLE
Sanitize email before requesting password reset

### DIFF
--- a/src/components/auth/ForgotPasswordModal.tsx
+++ b/src/components/auth/ForgotPasswordModal.tsx
@@ -64,8 +64,10 @@ export default function ForgotPasswordModal({
           ? `${window.location.origin}/connexion`
           : undefined)
 
+      const sanitizedEmail = email.trim()
+
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
-        email,
+        sanitizedEmail,
         redirectTo ? { redirectTo } : undefined
       )
 


### PR DESCRIPTION
## Summary
- trim the email address before invoking Supabase password reset to avoid extra whitespace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0dd80bf74832ebad6bce5de9d012d