### PR TITLE
Améliore l'interface de réinitialisation du mot de passe

### DIFF
--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -3,10 +3,9 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import { PasswordField } from "@/components/forms/PasswordField";
 import Spinner from "@/components/ui/Spinner";
 import { createClientComponentClient } from "@/lib/supabase/client";
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type Stage = "verify" | "reset" | "done" | "error";
 
@@ -16,16 +15,8 @@ export default function ResetPasswordPage() {
   const supabase = useMemo(() => createClientComponentClient(), []);
 
   const [email, setEmail] = useState("");
-  const [emailTouched, setEmailTouched] = useState(false);
-  const [emailFocused, setEmailFocused] = useState(false);
-
   const [password, setPassword] = useState("");
-  const [passwordTouched, setPasswordTouched] = useState(false);
-  const [passwordFocused, setPasswordFocused] = useState(false);
-
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [confirmTouched, setConfirmTouched] = useState(false);
-  const [confirmFocused, setConfirmFocused] = useState(false);
 
   const [stage, setStage] = useState<Stage>("verify");
   const [submitting, setSubmitting] = useState(false);
@@ -35,16 +26,10 @@ export default function ResetPasswordPage() {
   const refreshToken = searchParams?.get("refresh_token") || "";
   const type = searchParams?.get("type") || "";
 
-  const isEmailValid = EMAIL_REGEX.test(email.trim());
+  const isEmailValid = email.trim() !== "";
   const isPasswordValid = password.trim().length >= 8;
-  const isConfirmValid = confirmPassword.trim() !== "" && confirmPassword === password;
-
-  const shouldShowEmailError =
-    emailTouched && !emailFocused && email.trim() !== "" && !isEmailValid;
-  const shouldShowPasswordError =
-    passwordTouched && !passwordFocused && password.trim() !== "" && !isPasswordValid;
-  const shouldShowConfirmError =
-    confirmTouched && !confirmFocused && confirmPassword.trim() !== "" && !isConfirmValid;
+  const isConfirmValid =
+    confirmPassword.trim().length >= 8 && confirmPassword === password;
 
   useEffect(() => {
     let cancelled = false;
@@ -174,7 +159,7 @@ export default function ResetPasswordPage() {
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
       <div className="w-full max-w-md flex flex-col items-center px-4 sm:px-0">
         <h1 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-[24px]">
-          Réinitialiser le mot de passe
+          Modification du mot de passe
         </h1>
 
         {stage === "verify" && (
@@ -218,132 +203,99 @@ export default function ResetPasswordPage() {
         )}
 
         {stage === "reset" && (
-          <form
-            className="flex flex-col items-center w-full"
-            onSubmit={handleSubmit}
-            autoComplete="on"
-            name="reset-password"
-          >
-            <div className="w-full max-w-[368px]">
-              <label
-                htmlFor="email"
-                className="text-[16px] text-[#3A416F] font-bold mb-[5px] block"
-              >
-                Email
-              </label>
-              <input
-                id="email"
-                name="username"
-                type="email"
-                inputMode="email"
-                autoComplete="username"
-                placeholder="john.doe@email.com"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                onFocus={() => setEmailFocused(true)}
-                onBlur={() => {
-                  setEmailFocused(false);
-                  setEmailTouched(true);
-                }}
-                className={`h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 ${
-                  shouldShowEmailError
-                    ? "border border-[#EF4444]"
-                    : "border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
-                }`}
-              />
-              <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-                {shouldShowEmailError && (
-                  <p className="text-[#EF4444]">Format d’adresse invalide</p>
-                )}
+          <>
+            <div className="w-full max-w-[564px] mb-6">
+              <div className="relative bg-[#E7F0FF] rounded-[12px] px-6 py-5 text-left">
+                <span className="absolute left-0 top-0 h-full w-[4px] bg-[#4F78EF]" />
+                <h2 className="text-[#2E3271] font-bold text-[16px] mb-2">
+                  Modification de votre mot de passe
+                </h2>
+                <p className="text-[#4F78EF] font-semibold text-[13px] leading-relaxed">
+                  Pour finaliser votre demande de modification de votre mot de passe, saisissez un nouveau mot de passe, puis
+                  confirmez-le avant de cliquer sur « Enregistrer ».
+                </p>
               </div>
             </div>
 
-            <div className="w-full max-w-[368px] mb-[20px] relative">
-              <div className="flex items-end justify-between mb-[5px]">
+            <form
+              className="flex flex-col items-center w-full gap-[20px]"
+              onSubmit={handleSubmit}
+              autoComplete="on"
+              name="reset-password"
+            >
+              <div className="w-full max-w-[368px]">
                 <label
-                  htmlFor="password"
-                  className="text-[16px] text-[#3A416F] font-bold"
+                  htmlFor="email"
+                  className="text-[16px] text-[#3A416F] font-bold mb-[5px] block"
                 >
-                  Nouveau mot de passe
+                  Email
                 </label>
+                <input
+                  id="email"
+                  name="username"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="username"
+                  placeholder="john.doe@email.com"
+                  value={email}
+                  disabled
+                  className="h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] rounded-[5px] bg-[#F2F1F6] text-[#D7D4DC] border border-[#D7D4DC] cursor-not-allowed"
+                />
               </div>
-              <input
+
+              <PasswordField
                 id="password"
                 name="new-password"
-                type="password"
-                autoComplete="new-password"
+                label="Nouveau mot de passe"
                 placeholder="••••••••"
+                autoComplete="new-password"
                 value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                onFocus={() => setPasswordFocused(true)}
-                onBlur={() => {
-                  setPasswordFocused(false);
-                  setPasswordTouched(true);
-                }}
-                className="h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] pr-10 rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+                onChange={setPassword}
+                validate={(value) => value.trim().length >= 8}
+                errorMessage="Le mot de passe doit contenir au moins 8 caractères."
+                successMessage=""
+                containerClassName="w-full max-w-[368px]"
               />
-              <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-                {shouldShowPasswordError && (
-                  <p className="text-[#EF4444]">Mot de passe invalide</p>
-                )}
-              </div>
-            </div>
 
-            <div className="w-full max-w-[368px] mb-[20px] relative">
-              <div className="flex items-end justify-between mb-[5px]">
-                <label
-                  htmlFor="confirm"
-                  className="text-[16px] text-[#3A416F] font-bold"
-                >
-                  Confirmation
-                </label>
-              </div>
-              <input
+              <PasswordField
                 id="confirm"
                 name="confirm-password"
-                type="password"
-                autoComplete="new-password"
+                label="Répéter le nouveau mot de passe"
                 placeholder="••••••••"
+                autoComplete="new-password"
                 value={confirmPassword}
-                onChange={(event) => setConfirmPassword(event.target.value)}
-                onFocus={() => setConfirmFocused(true)}
-                onBlur={() => {
-                  setConfirmFocused(false);
-                  setConfirmTouched(true);
-                }}
-                className="h-[45px] w-full text-[16px] font-semibold placeholder-[#D7D4DC] px-[15px] pr-10 rounded-[5px] bg-white text-[#5D6494] transition-all duration-150 border border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]"
+                onChange={setConfirmPassword}
+                validate={(value) =>
+                  value.trim().length >= 8 && value === password
+                }
+                errorMessage="Les mots de passe ne correspondent pas."
+                successMessage=""
+                containerClassName="w-full max-w-[368px]"
               />
-              <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-                {shouldShowConfirmError && (
-                  <p className="text-[#EF4444]">
-                    Mince, le mot de passe ne correspond pas…
-                  </p>
-                )}
-              </div>
-            </div>
 
-            <div className="w-full flex justify-center">
-              <button
-                type="submit"
-                disabled={!isFormValid || submitting}
-                aria-busy={submitting}
-                className={`inline-flex h-[44px] items-center justify-center rounded-[25px] px-[15px] text-[16px] font-bold ${
-                  !isFormValid || submitting
-                    ? "bg-[#F2F1F6] text-[#D7D4DC] cursor-not-allowed"
-                    : "bg-[#7069FA] text-white hover:bg-[#6660E4]"
-                }`}
-              >
-                {submitting ? (
-                  <span className="inline-flex items-center gap-2">
-                    <Spinner size="md" ariaLabel="En cours" />
-                    En cours...
-                  </span>
-                ) : (
-                  "Valider"
-                )}
-              </button>
-            </div>
-          </form>
+              <div className="w-full flex justify-center">
+                <button
+                  type="submit"
+                  disabled={!isFormValid || submitting}
+                  aria-busy={submitting}
+                  className={`inline-flex h-[44px] items-center justify-center rounded-[25px] px-[15px] text-[16px] font-bold ${
+                    !isFormValid || submitting
+                      ? "bg-[#F2F1F6] text-[#D7D4DC] cursor-not-allowed"
+                      : "bg-[#7069FA] text-white hover:bg-[#6660E4]"
+                  }`}
+                >
+                  {submitting ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Spinner size="md" ariaLabel="En cours" />
+                      En cours...
+                    </span>
+                  ) : (
+                    "Enregistrer"
+                  )}
+                </button>
+              </div>
+            </form>
+          </>
         )}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- met à jour la page de réinitialisation pour suivre la nouvelle maquette et afficher le message explicatif
- désactive le champ e-mail et applique le composant partagé de mot de passe pour les deux champs requis
- ajuste le libellé du bouton et les validations afin d'assurer une expérience cohérente

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0e53d5c78832e95c703c9f9590ffc