### PR TITLE
Handle recovery session UI state

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,11 +11,11 @@ import CTAButton from "@/components/CTAButton";
 export default function Header() {
   const pathname = usePathname();
   const supabase = createClientComponentClient();
-  const { user, isAuthenticated } = useUser();
+  const { user, isAuthenticated, isRecoverySession } = useUser();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const showAuthenticatedUI = isAuthenticated;
+  const showAuthenticatedUI = isAuthenticated && !isRecoverySession;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary
- track the latest Supabase auth event and flag recovery sessions in the user context
- expose the new isRecoverySession flag to consumers
- hide authenticated header elements while a recovery session is active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0fa1ef0c0832eac528e7ecb610d62