### PR TITLE
Handle recovery session state transitions safely

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -151,7 +151,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
     const { data: authListener } = authClient.onAuthStateChange(
       (event, session) => {
-        latestAuthEventRef.current = event;
+        const previousEvent = latestAuthEventRef.current;
 
         if (event === "PASSWORD_RECOVERY") {
           setIsRecoverySession(true);
@@ -161,9 +161,16 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
         if (sessionType === "recovery") {
           setIsRecoverySession(true);
-        } else if (event === "SIGNED_OUT" || event === "SIGNED_IN") {
+        } else if (
+          event === "SIGNED_OUT" ||
+          (event === "SIGNED_IN" &&
+            sessionType !== "recovery" &&
+            (sessionType !== undefined || previousEvent !== "PASSWORD_RECOVERY"))
+        ) {
           setIsRecoverySession(false);
         }
+
+        latestAuthEventRef.current = event;
 
         void fetchUser();
       },


### PR DESCRIPTION
## Summary
- keep tracking of the previous auth event to avoid clearing the recovery flag too early
- only reset `isRecoverySession` when receiving a clear sign-out or a non-recovery sign-in

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e101254994832e8e0d0a7379dbe072