### PR TITLE
Allow password reset flow to return to login

### DIFF
--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -211,17 +211,29 @@ export default function ResetPasswordPage() {
       });
       if (updateError) throw updateError;
 
+      const { error: signOutError } = await supabase.auth.signOut({
+        scope: "local",
+      });
+      if (signOutError) {
+        console.error("Erreur lors de la déconnexion après réinitialisation", signOutError);
+      }
+
       setStage("done");
       setFormError(null);
 
+      const params = new URLSearchParams({ reset: "success" });
+      const isNextSafe = next.startsWith("/") && !next.startsWith("//");
+      if (isNextSafe) {
+        params.set("next", next);
+      }
+
+      const loginUrl = `/connexion${
+        params.toString() ? `?${params.toString()}` : ""
+      }`;
+
       window.setTimeout(() => {
-        try {
-          const destination = new URL(next);
-          window.location.href = destination.toString();
-        } catch {
-          router.push(next);
-          router.refresh();
-        }
+        router.push(loginUrl);
+        router.refresh();
       }, 600);
     } catch (unknownError) {
       console.error("Erreur lors de la mise à jour du mot de passe", unknownError);
@@ -279,7 +291,7 @@ export default function ResetPasswordPage() {
             <ModalMessage
               variant="success"
               title="Mot de passe mis à jour"
-              description="Redirection en cours…"
+              description="Tu vas être redirigé vers la page de connexion pour utiliser ton nouveau mot de passe."
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- redirect the password reset flow to the login page after updating the password and clear the temporary session
- surface a success notice on the login page and honour any `next` parameter before redirecting post-login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e103b15294832eb30e137ed8549874