### PR TITLE
Fix password recovery session type handling

### DIFF
--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -202,10 +202,15 @@ export default function ResetPasswordPage() {
 
         const existingSession = existingSessionData?.session ?? null;
 
+        const existingSessionType =
+          (
+            existingSession as (typeof existingSession & { type?: string }) | null
+          )?.type ?? type;
+
         if (
           existingSession?.access_token &&
           existingSession?.refresh_token &&
-          (existingSession.type ?? type) === "recovery"
+          existingSessionType === "recovery"
         ) {
           const candidateFromExistingSession: SessionTokenSet = {
             accessToken: existingSession.access_token,


### PR DESCRIPTION
## Summary
- guard access to the Supabase session type by using a safe cast and fallback to the query parameter
- keep the password reset flow working when an existing recovery session is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e12db968ec832e904571de0c033bb0