### PR TITLE
Fix TypeScript typing errors in admin and authentication pages

### DIFF
--- a/src/app/admin/entrainements/page.tsx
+++ b/src/app/admin/entrainements/page.tsx
@@ -23,7 +23,6 @@ export default function AdminSingleProgramPage() {
   const [program, setProgram] = useState<Program | null>(null);
   const [originalName, setOriginalName] = useState<string>("Nouveau programme");
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [activeTraining, setActiveTraining] = useState<Training | null>(null);
   const [openVisibilityIds, setOpenVisibilityIds] = useState<string[]>([]);
 
@@ -176,13 +175,11 @@ export default function AdminSingleProgramPage() {
 
   const handleDragStart = (event: DragStartEvent) => {
     const { id } = event.active;
-    setActiveId(id as string);
     const training = program?.trainings.find((t) => t.id === id);
     if (training) setActiveTraining(training);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
-    setActiveId(null);
     setActiveTraining(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -260,7 +257,6 @@ export default function AdminSingleProgramPage() {
               openVisibilityIds={openVisibilityIds}
               setOpenVisibilityIds={setOpenVisibilityIds}
               onUpdateTrainingVisibility={() => {}}
-              activeId={activeId}
             />
           </div>
 

--- a/src/app/admin/program/page.tsx
+++ b/src/app/admin/program/page.tsx
@@ -22,13 +22,13 @@ type Program = ProgramRow & {
   linked: boolean;
 };
 
+type SortableColumn = "created_at" | "name" | "linked" | "id";
+
 export default function AdminProgramPage() {
   const [programs, setPrograms] = useState<Program[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [showActionsBar, setShowActionsBar] = useState(false);
-  const [sortBy, setSortBy] = useState<"created_at" | "name" | "linked" | "id">(
-    "created_at"
-  );
+  const [sortBy, setSortBy] = useState<SortableColumn>("created_at");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -44,9 +44,10 @@ export default function AdminProgramPage() {
 
   const fetchPrograms = useCallback(async () => {
     setLoading(true);
-    const { data: rawPrograms, error } = await supabase.rpc<ProgramRow>(
-      "programs_admin_with_count"
-    );
+    const { data: rawPrograms, error } = await supabase.rpc<
+      ProgramRow[],
+      Record<string, never>
+    >("programs_admin_with_count");
     if (error) {
       console.error("Erreur Supabase (programs):", error);
       setLoading(false);
@@ -103,7 +104,7 @@ export default function AdminProgramPage() {
     void fetchPrograms();
   }, [fetchPrograms]);
 
-  const handleSort = (column: string) => {
+  const handleSort = (column: SortableColumn) => {
     if (sortBy === column) {
       setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
@@ -238,7 +239,7 @@ export default function AdminProgramPage() {
   const [searchTerm, setSearchTerm] = useState("");
 
   const filteredPrograms = programs.filter((p) =>
-  p.name.toLowerCase().includes(searchTerm.toLowerCase())
+    p.name.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   return (

--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -37,8 +37,8 @@ export default function ConnexionPage() {
   const isEmailValidFormat = isValidEmail(email);
   const isFormValid = isEmailValidFormat && password.trim() !== "";
 
-  const nextParam = searchParams.get("next");
-  const resetStatus = searchParams.get("reset");
+  const nextParam = searchParams?.get("next") ?? null;
+  const resetStatus = searchParams?.get("reset") ?? null;
 
   const isNextSafe = useMemo(() => {
     if (!nextParam) return null;
@@ -54,6 +54,10 @@ export default function ConnexionPage() {
   useEffect(() => {
     if (resetStatus === "success") {
       setShowResetSuccess(true);
+
+      if (!searchParams) {
+        return;
+      }
 
       const params = new URLSearchParams(searchParams.toString());
       params.delete("reset");

--- a/src/app/entrainements/page.tsx
+++ b/src/app/entrainements/page.tsx
@@ -47,7 +47,6 @@ export default function EntrainementsPage() {
   const [showProgramDeleteModal, setShowProgramDeleteModal] = useState(false);
   const [programIdToDelete, setProgramIdToDelete] = useState<string | null>(null);
 
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [activeTraining, setActiveTraining] = useState<Training | null>(null);
   const [activeProgramId, setActiveProgramId] = useState<string | null>(null);
 
@@ -91,7 +90,6 @@ export default function EntrainementsPage() {
 
   const handleDragStart = (event: DragStartEvent) => {
     const { id, data } = event.active;
-    setActiveId(id as string);
     setActiveProgramId(data?.current?.programId ?? null);
 
     const current = programs
@@ -138,7 +136,6 @@ export default function EntrainementsPage() {
   const handleDragEnd = async (event: DragEndEvent) => {
     setProgramsDuringDrag(null);
     const { active, over } = event;
-    setActiveId(null);
     if (!over) return;
 
     const fromProgramId = activeProgramId;
@@ -318,10 +315,11 @@ export default function EntrainementsPage() {
             }
             onAddTraining={async () => {
               if (!program.id) return;
-            const newData = await handleAddTraining(program.id);
-            if (newData?.id) {
-              router.push(`/entrainements/${newData.id}?new=1`);
-            }
+
+              const newData = await handleAddTraining(program.id);
+              if (newData?.id) {
+                router.push(`/entrainements/${newData.id}?new=1`);
+              }
             }}
             onDeleteTraining={(id: string) => handleDeleteTraining(program.id, id)}
             onDuplicateTraining={(id: string) => handleDuplicateTraining(program.id, id)}
@@ -329,7 +327,6 @@ export default function EntrainementsPage() {
             openVisibilityIds={openVisibilityIds}
             setOpenVisibilityIds={setOpenVisibilityIds}
             onUpdateTrainingVisibility={handleUpdateTrainingVisibility}
-            activeId={activeId}
           />
         </div>
       );

--- a/src/components/DroppableProgram.tsx
+++ b/src/components/DroppableProgram.tsx
@@ -31,7 +31,6 @@ interface Props {
   showVisibilityTrainingId?: string | null
   setShowVisibilityTrainingId?: (id: string | null) => void
   onUpdateTrainingVisibility: (id: string, updates: Partial<{ app: boolean; dashboard: boolean }>) => void
-  activeId: string | null
 }
 
 export default function DroppableProgram(props: Props) {
@@ -45,7 +44,6 @@ export default function DroppableProgram(props: Props) {
     openVisibilityIds,
     setOpenVisibilityIds,
     onUpdateTrainingVisibility,
-    activeId,
   } = props;
 
   const { setNodeRef } = useDroppable({
@@ -88,7 +86,6 @@ export default function DroppableProgram(props: Props) {
               showVisibility={openVisibilityIds.includes(training.id)}
               dragDisabled={dragDisabled}
               onUpdateTrainingVisibility={onUpdateTrainingVisibility}
-              activeId={activeId}
             />
           ))}
           <div className="ml-0">

--- a/src/components/ProgramEditor.tsx
+++ b/src/components/ProgramEditor.tsx
@@ -75,7 +75,7 @@ export default function ProgramEditor({
     }
 
     const { data, error } = await supabase
-      .from<ProgramTrainingSummary>(tableName)
+      .from(tableName)
       .select("id, name, program_id, position, app, dashboard")
       .eq("program_id", programId);
 
@@ -84,14 +84,16 @@ export default function ProgramEditor({
       return;
     }
 
-    const sanitized = (data ?? []).map((row) => ({
-      id: String(row.id),
-      name: row.name ?? null,
-      program_id: row.program_id ?? programId,
-      position: row.position ?? null,
-      app: row.app ?? null,
-      dashboard: row.dashboard ?? null,
-    }));
+    const sanitized = ((data as ProgramTrainingSummary[] | null) ?? []).map(
+      (row) => ({
+        id: String(row.id),
+        name: row.name ?? null,
+        program_id: row.program_id ?? programId,
+        position: row.position ?? null,
+        app: row.app ?? null,
+        dashboard: row.dashboard ?? null,
+      })
+    );
 
     setTrainingsData(sanitized);
   }, [programId, supabase, tableName]);

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -157,7 +157,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           setIsRecoverySession(true);
         }
 
-        const sessionType = session?.type;
+        const sessionType = extractSessionType(session);
 
         if (sessionType === "recovery") {
           setIsRecoverySession(true);


### PR DESCRIPTION
## Summary
- tighten Supabase RPC typing and column handling in the admin program listing, and keep filtering strongly typed
- guard access to optional URL search params on the connexion page and adjust Supabase data casting in the program editor
- align drag-and-drop components by removing unused active identifiers and updating props to match current usage
- ensure recovery session detection reads the session type safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e13dc5adec832e94cb84b6e9ed276a