### PR TITLE
Fix React type resolution for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,11 @@
     "jsx": "preserve",
     "incremental": true,
     "baseUrl": ".",
+    "types": [
+      "react",
+      "react-dom",
+      "node"
+    ],
     "paths": {
       "@/*": [
         "src/*"


### PR DESCRIPTION
## Summary
- ensure the TypeScript compiler loads the React, React DOM, and Node type definitions so JSX is properly typed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14b3e34f4832eb6666398201c758c