### PR TITLE
Fix Supabase middleware TypeScript typing issues

### DIFF
--- a/src/types/set-cookie-parser.d.ts
+++ b/src/types/set-cookie-parser.d.ts
@@ -1,0 +1,5 @@
+declare module "set-cookie-parser" {
+  export function splitCookiesString(
+    cookiesString: string | string[] | null | undefined,
+  ): string[];
+}


### PR DESCRIPTION
## Summary
- update the Supabase middleware cookie helpers to use the cookie package types and ensure parsed cookies are typed
- add a local type declaration for the set-cookie-parser module to satisfy TypeScript

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14d086a38832e8702bcfee151fb30