### PR TITLE
Fix type declarations for Supabase middleware cookies

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -55,12 +55,13 @@ class RememberMiddlewareAuthStorageAdapter extends CookieAuthStorageAdapter {
   protected getCookie(name: string): string | null | undefined {
     const responseCookies = splitCookiesString(
       this.context.res.headers.get("set-cookie")?.toString() ?? "",
-    ).map<string | undefined>(
-      (cookieString) => parseCookies(cookieString)[name],
+    ).map<string | undefined>((cookieString: string) =>
+      parseCookies(cookieString)[name],
     );
 
     const setCookie = responseCookies.find(
-      (cookieValue): cookieValue is string | undefined => Boolean(cookieValue),
+      (cookieValue: string | undefined): cookieValue is string | undefined =>
+        Boolean(cookieValue),
     );
 
     if (setCookie) {

--- a/types/set-cookie-parser.d.ts
+++ b/types/set-cookie-parser.d.ts
@@ -1,3 +1,5 @@
 declare module "set-cookie-parser" {
-  export function splitCookiesString(cookiesString: string): string[];
+  export function splitCookiesString(
+    cookiesString: string | readonly string[],
+  ): string[];
 }


### PR DESCRIPTION
## Summary
- add type annotations to the Supabase middleware cookie helpers
- extend the local declaration for `set-cookie-parser` to cover the supported inputs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e151040e48832e9b1553d3868fc332