### PR TITLE
Handle recovery session state during Supabase auth flow

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -161,11 +161,12 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
         if (sessionType === "recovery") {
           setIsRecoverySession(true);
+        } else if (event === "SIGNED_OUT") {
+          setIsRecoverySession(false);
         } else if (
-          event === "SIGNED_OUT" ||
-          (event === "SIGNED_IN" &&
-            sessionType !== "recovery" &&
-            (sessionType !== undefined || previousEvent !== "PASSWORD_RECOVERY"))
+          event === "SIGNED_IN" &&
+          sessionType !== "recovery" &&
+          previousEvent !== "PASSWORD_RECOVERY"
         ) {
           setIsRecoverySession(false);
         }


### PR DESCRIPTION
## Summary
- prevent clearing the recovery session flag immediately after password recovery sign-in events
- only reset the recovery flag after an explicit sign-out or a later non-recovery sign-in

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e244ac66f8832e849aa1978a03121f