### PR TITLE
Remove password match indicator and redirect login to trainings

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { EmailField, isValidEmail } from "@/components/forms/EmailField";
@@ -37,15 +37,7 @@ export default function ConnexionPage() {
   const isEmailValidFormat = isValidEmail(email);
   const isFormValid = isEmailValidFormat && password.trim() !== "";
 
-  const nextParam = searchParams?.get("next") ?? null;
   const resetStatus = searchParams?.get("reset") ?? null;
-
-  const isNextSafe = useMemo(() => {
-    if (!nextParam) return null;
-    if (!nextParam.startsWith("/")) return null;
-    if (nextParam.startsWith("//")) return null;
-    return nextParam;
-  }, [nextParam]);
 
   const [showResetSuccess, setShowResetSuccess] = useState(
     resetStatus === "success"
@@ -110,8 +102,7 @@ export default function ConnexionPage() {
         if (data?.session) {
           await supabase.auth.setSession(data.session);
         }
-        const destination = isNextSafe ?? "/entrainements";
-        router.push(destination);
+        router.push("/entrainements");
         router.refresh();
       } else if (error.message === "Invalid login credentials") {
         setError({

--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -50,10 +50,8 @@ function PasswordCriteriaItem({
 
 function PasswordCriteriaList({
   validation,
-  includeMatch = false,
 }: {
   validation: PasswordValidationWithMatch;
-  includeMatch?: boolean;
 }) {
   return (
     <div
@@ -70,12 +68,6 @@ function PasswordCriteriaList({
         valid={validation.hasSymbol}
         text="Au moins 1 symbole"
       />
-      {includeMatch ? (
-        <PasswordCriteriaItem
-          valid={Boolean(validation.matches)}
-          text="Correspond au mot de passe"
-        />
-      ) : null}
     </div>
   );
 }
@@ -202,10 +194,7 @@ export default function ResetPasswordPage() {
   const confirmCriteriaRenderer = useCallback<CriteriaRenderer>(
     ({ isFocused }) =>
       isFocused ? (
-        <PasswordCriteriaList
-          validation={confirmValidation}
-          includeMatch
-        />
+        <PasswordCriteriaList validation={confirmValidation} />
       ) : null,
     [confirmValidation]
   );


### PR DESCRIPTION
## Summary
- remove the password match criterion from the reset password confirmation helper
- ensure the login flow always redirects authenticated users to /entrainements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e257521a94832e802fb5480b455118