### PR TITLE
Show loader while redirecting after login

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -13,6 +13,7 @@ import Spinner from "@/components/ui/Spinner";
 import ErrorMessage from "@/components/ui/ErrorMessage";
 import ForgotPasswordModal from "@/components/auth/ForgotPasswordModal";
 import ModalMessage from "@/components/ui/ModalMessage";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 export default function ConnexionPage() {
   const [email, setEmail] = useState("");
@@ -29,6 +30,7 @@ export default function ConnexionPage() {
   >(null);
   const [loading, setLoading] = useState(false);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
+  const [showTransitionLoader, setShowTransitionLoader] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -102,6 +104,7 @@ export default function ConnexionPage() {
         if (data?.session) {
           await supabase.auth.setSession(data.session);
         }
+        setShowTransitionLoader(true);
         router.push("/entrainements");
         router.refresh();
       } else if (error.message === "Invalid login credentials") {
@@ -140,6 +143,7 @@ export default function ConnexionPage() {
 
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
+      {showTransitionLoader ? <GliftLoader /> : null}
       <div className="w-full max-w-[564px] flex flex-col items-center">
         <h1 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-6">
           Connexion


### PR DESCRIPTION
## Summary
- display the Glift loader overlay once authentication succeeds
- keep the loader visible while redirecting users from the login page to /entrainements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26aade7cc832e847c8cee3a41e090