### PR TITLE
Use GliftLoader across loading states

### DIFF
--- a/src/app/admin/create-offer/page.tsx
+++ b/src/app/admin/create-offer/page.tsx
@@ -8,6 +8,7 @@ import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import { AdminTextField } from "@/app/admin/components/AdminTextField";
 import AdminMultiSelectDropdown from "@/components/AdminMultiSelectDropdown";
 import CTAButton from "@/components/CTAButton";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 const days = Array.from({ length: 31 }, (_, i) => (i + 1).toString().padStart(2, "0"));
 const months = [
@@ -171,18 +172,18 @@ export default function CreateOfferPage() {
   };
 
   return (
-    <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
-      <div className="w-full max-w-3xl">
-        <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">
-          {offerId ? "Modifier l’offre" : "Créer une offre"}
-        </h2>
+    <>
+      {loading && <GliftLoader />}
+      <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
+        <div className="w-full max-w-3xl">
+          <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">
+            {offerId ? "Modifier l’offre" : "Créer une offre"}
+          </h2>
 
-        {loading ? (
-          <p className="text-center text-[#5D6494]">Chargement...</p>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-            {/* Date de début */}
-            <div className="flex flex-col">
+          {!loading && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+                {/* Date de début */}
+                <div className="flex flex-col">
               <label className="text-[#3A416F] font-bold mb-1">Date de début</label>
               <div className="flex gap-2">
                 {(() => {
@@ -538,9 +539,10 @@ export default function CreateOfferPage() {
                 {offerId ? "Mettre à jour" : "Créer l’offre"}
               </CTAButton>
             </div>
-          </div>
-        )}
-      </div>
-    </main>
+            </div>
+          )}
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/app/admin/create-program/page.tsx
+++ b/src/app/admin/create-program/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabaseClient";
 import ImageUploader from "@/app/admin/components/ImageUploader";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import CTAButton from "@/components/CTAButton";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 type Program = {
   id?: number;
@@ -169,15 +170,15 @@ export default function CreateProgramPage() {
   );
 
   return (
-    <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
-      <div className="w-full max-w-3xl px-4 sm:px-0">
-        <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">
-          {programId ? "Modifier la carte" : "Créer une carte"}
-        </h2>
+    <>
+      {loading && <GliftLoader />}
+      <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
+        <div className="w-full max-w-3xl px-4 sm:px-0">
+          <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">
+            {programId ? "Modifier la carte" : "Créer une carte"}
+          </h2>
 
-        {loading ? (
-          <p className="text-center text-[#5D6494]">Chargement...</p>
-        ) : (
+        {!loading && (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
               {/* Sexe */}
@@ -196,26 +197,26 @@ export default function CreateProgramPage() {
                 />
               </div>
 
-              {/* Image principale */}
-              <div className="flex flex-col">
-              <div className="flex justify-between mb-[5px]">
-                <span className="text-[16px] text-[#3A416F] font-bold">Image principale</span>
-                <span className="text-[12px] text-[#C2BFC6] font-semibold mt-[3px]">270px x 180px</span>
-              </div>
-                <ImageUploader
-                  value={program.image}
-                  onChange={(url) => setProgram({ ...program, image: url })}
-                />
-              </div>
+                {/* Image principale */}
+                <div className="flex flex-col">
+                  <div className="flex justify-between mb-[5px]">
+                    <span className="text-[16px] text-[#3A416F] font-bold">Image principale</span>
+                    <span className="text-[12px] text-[#C2BFC6] font-semibold mt-[3px]">270px x 180px</span>
+                  </div>
+                  <ImageUploader
+                    value={program.image}
+                    onChange={(url) => setProgram({ ...program, image: url })}
+                  />
+                </div>
 
-              {/* Titre */}
-              <div className="flex flex-col">
-              <div className="flex justify-between mb-[5px]">
-                <span className="text-[16px] text-[#3A416F] font-bold">Titre</span>
-                <span className="text-[12px] text-[#C2BFC6] font-semibold mt-[3px]">
-                  {program.title.length}/52
-                </span>
-              </div>
+                {/* Titre */}
+                <div className="flex flex-col">
+                  <div className="flex justify-between mb-[5px]">
+                    <span className="text-[16px] text-[#3A416F] font-bold">Titre</span>
+                    <span className="text-[12px] text-[#C2BFC6] font-semibold mt-[3px]">
+                      {program.title.length}/52
+                    </span>
+                  </div>
                 <input
                   type="text"
                   placeholder="Titre du programme"
@@ -431,9 +432,10 @@ export default function CreateProgramPage() {
               {programId ? "Mettre à jour" : "Créer la carte"}
             </CTAButton>
           </div>
-        </>
-      )}
-    </div>
-  </main>
+          </>
+        )}
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/app/admin/slider/page.tsx
+++ b/src/app/admin/slider/page.tsx
@@ -6,6 +6,7 @@ import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import ImageUploader from "@/app/admin/components/ImageUploader";
 import { AdminTextField } from "@/app/admin/components/AdminTextField";
 import CTAButton from "@/components/CTAButton";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 const sliderTypeOptions = [
   { value: "none", label: "Aucun slider" },
@@ -134,15 +135,15 @@ export default function AdminSliderPage() {
   };
 
   return (
-    <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
-      <div className="w-full max-w-3xl">
-        <h2 className="text-[30px] font-bold text-[#2E3271] text-center mb-10">
-          Slider
-        </h2>
+    <>
+      {loading && <GliftLoader />}
+      <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
+        <div className="w-full max-w-3xl">
+          <h2 className="text-[30px] font-bold text-[#2E3271] text-center mb-10">
+            Slider
+          </h2>
 
-        {loading ? (
-          <p className="text-center text-[#5D6494]">Chargement...</p>
-        ) : (
+        {!loading && (
           <>
             {type !== "none" && (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
@@ -246,5 +247,6 @@ export default function AdminSliderPage() {
         </div>
       </div>
     </main>
+  </>
   );
 }

--- a/src/app/post-inscription/page.tsx
+++ b/src/app/post-inscription/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 export default function PostInscription() {
   const params = useSearchParams();
@@ -19,14 +20,17 @@ export default function PostInscription() {
   }, []);  
 
   return (
-    <form
-      id="authForm"
-      method="POST"
-      action="/api/auth/login?returnTo=/entrainements"
-      style={{ display: "none" }}
-    >
-      <input type="hidden" name="email" value={email} />
-      <input type="hidden" name="password" value={password} />
-    </form>
+    <>
+      <GliftLoader />
+      <form
+        id="authForm"
+        method="POST"
+        action="/api/auth/login?returnTo=/entrainements"
+        style={{ display: "none" }}
+      >
+        <input type="hidden" name="email" value={email} />
+        <input type="hidden" name="password" value={password} />
+      </form>
+    </>
   );
 }

--- a/src/components/shop/ShopGrid.tsx
+++ b/src/components/shop/ShopGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import ShopCard from "@/components/shop/ShopCard";
+import GliftLoader from "@/components/ui/GliftLoader";
 import { createClient } from "@/lib/supabaseClient";
 
 type Offer = {
@@ -141,37 +142,35 @@ export default function ShopGrid({
     });
 
   return (
-    <div className="relative mt-8">
-      {filteredOffers.length === 0 && !loading && (
-        <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
-      )}
+    <>
+      {loading && <GliftLoader />}
+      <div className="relative mt-8">
+        {filteredOffers.length === 0 && !loading && (
+          <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
+        )}
 
-      <div className="grid gap-6 grid-cols-[repeat(auto-fill,minmax(270px,1fr))] justify-center">
-        {filteredOffers.map((offer) => (
-        <ShopCard
-          key={offer.id}
-          offer={{
-            ...offer,
-            type: Array.isArray(offer.type)
-              ? offer.type
-              : (() => {
-                  try {
-                    const parsed = JSON.parse(offer.type || "[]");
-                    return Array.isArray(parsed) ? parsed : [parsed];
-                  } catch {
-                    return [];
-                  }
-                })(),
-          }}
-        />
-        ))}
-      </div>
-
-      {loading && (
-        <div className="absolute inset-0 bg-white/60 backdrop-blur-sm flex items-center justify-center">
-          <span className="text-[#5D6494] font-semibold">Chargement...</span>
+        <div className="grid gap-6 grid-cols-[repeat(auto-fill,minmax(270px,1fr))] justify-center">
+          {filteredOffers.map((offer) => (
+            <ShopCard
+              key={offer.id}
+              offer={{
+                ...offer,
+                type: Array.isArray(offer.type)
+                  ? offer.type
+                  : (() => {
+                      try {
+                        const parsed = JSON.parse(offer.type || "[]");
+                        return Array.isArray(parsed) ? parsed : [parsed];
+                      } catch {
+                        return [];
+                      }
+                    })(),
+              }}
+            />
+          ))}
         </div>
-      )}
-    </div>
+
+      </div>
+    </>
   );
 }

--- a/src/components/store/StoreGrid.tsx
+++ b/src/components/store/StoreGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import StoreCard from "@/components/store/StoreCard";
+import GliftLoader from "@/components/ui/GliftLoader";
 import { createClient } from "@/lib/supabaseClient";
 
 type Program = {
@@ -115,26 +116,24 @@ export default function StoreGrid({
   }, [sortBy, currentPage, filters]);
 
   return (
-    <div className="relative mt-8">
-      {programs.length === 0 && !loading && (
-        <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
-      )}
+    <>
+      {loading && <GliftLoader />}
+      <div className="relative mt-8">
+        {programs.length === 0 && !loading && (
+          <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
+        )}
 
-      <div className="grid gap-6 grid-cols-[repeat(auto-fill,minmax(270px,1fr))] justify-center">
-        {programs.map((program) => (
-          <StoreCard
-            key={program.id}
-            program={program}
-            isAuthenticated={isAuthenticated}
-          />
-        ))}
-      </div>
-
-      {loading && (
-        <div className="absolute inset-0 bg-white/60 backdrop-blur-sm flex items-center justify-center">
-          <span className="text-[#5D6494] font-semibold">Chargement...</span>
+        <div className="grid gap-6 grid-cols-[repeat(auto-fill,minmax(270px,1fr))] justify-center">
+          {programs.map((program) => (
+            <StoreCard
+              key={program.id}
+              program={program}
+              isAuthenticated={isAuthenticated}
+            />
+          ))}
         </div>
-      )}
-    </div>
+
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- integrate the GliftLoader component into the post-inscription flow and store/shop grids for consistent loading feedback
- replace text-based loading placeholders on admin create-offer and create-program forms with the shared loader overlay
- apply the same loader to the admin slider configuration page during Supabase fetch/save operations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26ca47210832e93ed7305485b0458