### PR TITLE
feat: highlight incomplete account fields

### DIFF
--- a/public/icons/missing.svg
+++ b/public/icons/missing.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10.5" fill="#F4F5FE" stroke="#7069FA" stroke-width="1.5" />
+  <rect x="11" y="6" width="2" height="9" rx="1" fill="#7069FA" />
+  <circle cx="12" cy="17" r="1.25" fill="#7069FA" />
+</svg>

--- a/src/components/account/IncompleteAlert.tsx
+++ b/src/components/account/IncompleteAlert.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import Image from 'next/image'
+
+export default function IncompleteAlert() {
+  return (
+    <div className="w-[564px] max-w-full mt-4">
+      <div className="relative bg-[#F4F5FE] rounded-[5px] px-5 py-2.5 text-left">
+        <span className="absolute left-0 top-0 h-full w-[3px] bg-[#A1A5FD]" />
+        <h3 className="text-[#7069FA] font-bold text-[12px]">Complétez votre profil</h3>
+        <p className="text-[#A1A5FD] font-semibold text-[12px] leading-relaxed">
+          Complétez les informations manquantes indiquées par un{' '}
+          <span className="inline-flex items-center justify-center align-[-7px] w-[24px] h-[24px] rounded-full">
+            <Image src="/icons/missing.svg" alt="" width={24} height={24} />
+          </span>{' '}
+          et personnalisez votre expérience avec Glift.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -18,6 +18,8 @@ import EmailInfoAdornment from "./fields/EmailInfoAdornment"
 import SubmitButton from "./fields/SubmitButton"
 import TextField from "./fields/TextField"
 import ToggleField from "./fields/ToggleField"
+import IncompleteAlert from "./IncompleteAlert"
+import MissingField from "./fields/MissingField"
 
 export default function MesInformationsForm({ user }: { user: User | null }) {
   const {
@@ -36,6 +38,25 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
     startNameEdition,
     endNameEdition,
   } = useAccountForm(user)
+
+  const trimmedName = values.name.trim()
+  const missing = {
+    gender: !values.gender,
+    name: trimmedName.length === 0,
+    birthDate:
+      !values.birthDate.birthDay ||
+      !values.birthDate.birthMonth ||
+      !values.birthDate.birthYear,
+    country: !values.country,
+    experience: !values.experience,
+    mainGoal: !values.mainGoal,
+    trainingPlace: !values.trainingPlace,
+    weeklySessions: !values.weeklySessions,
+    supplements: values.supplements === "",
+    email: !user?.email,
+  }
+
+  const hasIncomplete = Object.values(missing).some(Boolean)
 
   return (
     <form
@@ -56,206 +77,228 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
         </div>
       )}
 
-      <ToggleField
-        label="Sexe"
-        value={values.gender}
-        options={Array.from(GENDER_OPTIONS)}
-        onChange={(option) => {
-          resetSuppress()
-          updateValue("gender", (current) => (current === option ? "" : option))
-          markTouched({ gender: true })
-        }}
-        touched={latchedTouched.gender}
-        setTouched={() => {
-          resetSuppress()
-          markTouched({ gender: true })
-        }}
-        success={successMessages.gender}
-      />
+      {hasIncomplete && <IncompleteAlert />}
 
-      <TextField
-        label="Prénom"
-        value={values.name}
-        onChange={(next) => {
-          resetSuppress()
-          updateValue("name", next)
-        }}
-        onBlur={() => {
-          endNameEdition()
-        }}
-        onFocus={() => {
-          resetSuppress()
-          startNameEdition()
-        }}
-        success={successMessages.name}
-      />
-
-      <BirthDateField
-        birthDay={values.birthDate.birthDay}
-        birthMonth={values.birthDate.birthMonth}
-        birthYear={values.birthDate.birthYear}
-        setBirthDay={(next) => {
-          resetSuppress()
-          updateBirthDatePart("birthDay", next)
-          markTouched({ birthDay: true })
-        }}
-        setBirthMonth={(next) => {
-          resetSuppress()
-          updateBirthDatePart("birthMonth", next)
-          markTouched({ birthMonth: true })
-        }}
-        setBirthYear={(next) => {
-          resetSuppress()
-          updateBirthDatePart("birthYear", next)
-          markTouched({ birthYear: true })
-        }}
-        touched={{
-          birthDay: latchedTouched.birthDay,
-          birthMonth: latchedTouched.birthMonth,
-          birthYear: latchedTouched.birthYear,
-        }}
-        setTouched={(partial) => {
-          resetSuppress()
-          markTouched(partial)
-        }}
-        successMessage={successMessages.birthDate ?? ""}
-        initialBirthDay={initialBirthParts.birthDay}
-        initialBirthMonth={initialBirthParts.birthMonth}
-        initialBirthYear={initialBirthParts.birthYear}
-      />
-
-      <TextField
-        label="Email"
-        value={user?.email || ""}
-        disabled
-        endAdornment={<EmailInfoAdornment />}
-      />
-
-      <div
-        onMouseDown={() => {
-          resetSuppress()
-        }}
-      >
-        <DropdownField
-          label="Pays de résidence"
-          placeholder="Sélectionnez un pays"
-          selected={values.country}
-          onSelect={(option) => {
+      <MissingField show={missing.gender}>
+        <ToggleField
+          label="Sexe"
+          value={values.gender}
+          options={Array.from(GENDER_OPTIONS)}
+          onChange={(option) => {
             resetSuppress()
-            updateValue("country", option)
-            markTouched({ country: true })
+            updateValue("gender", (current) => (current === option ? "" : option))
+            markTouched({ gender: true })
           }}
-          options={Array.from(COUNTRIES).map((country) => ({
-            value: country,
-            label: country,
-          }))}
-          touched={latchedTouched.country}
-          setTouched={(isTouched) => {
-            if (isTouched) {
+          touched={latchedTouched.gender}
+          setTouched={() => {
+            resetSuppress()
+            markTouched({ gender: true })
+          }}
+          success={successMessages.gender}
+        />
+      </MissingField>
+
+      <MissingField show={missing.name}>
+        <TextField
+          label="Prénom"
+          value={values.name}
+          onChange={(next) => {
+            resetSuppress()
+            updateValue("name", next)
+          }}
+          onBlur={() => {
+            endNameEdition()
+          }}
+          onFocus={() => {
+            resetSuppress()
+            startNameEdition()
+          }}
+          success={successMessages.name}
+        />
+      </MissingField>
+
+      <MissingField show={missing.birthDate}>
+        <BirthDateField
+          birthDay={values.birthDate.birthDay}
+          birthMonth={values.birthDate.birthMonth}
+          birthYear={values.birthDate.birthYear}
+          setBirthDay={(next) => {
+            resetSuppress()
+            updateBirthDatePart("birthDay", next)
+            markTouched({ birthDay: true })
+          }}
+          setBirthMonth={(next) => {
+            resetSuppress()
+            updateBirthDatePart("birthMonth", next)
+            markTouched({ birthMonth: true })
+          }}
+          setBirthYear={(next) => {
+            resetSuppress()
+            updateBirthDatePart("birthYear", next)
+            markTouched({ birthYear: true })
+          }}
+          touched={{
+            birthDay: latchedTouched.birthDay,
+            birthMonth: latchedTouched.birthMonth,
+            birthYear: latchedTouched.birthYear,
+          }}
+          setTouched={(partial) => {
+            resetSuppress()
+            markTouched(partial)
+          }}
+          successMessage={successMessages.birthDate ?? ""}
+          initialBirthDay={initialBirthParts.birthDay}
+          initialBirthMonth={initialBirthParts.birthMonth}
+          initialBirthYear={initialBirthParts.birthYear}
+        />
+      </MissingField>
+
+      <MissingField show={missing.email}>
+        <TextField
+          label="Email"
+          value={user?.email || ""}
+          disabled
+          endAdornment={<EmailInfoAdornment />}
+        />
+      </MissingField>
+
+      <MissingField show={missing.country}>
+        <div
+          onMouseDown={() => {
+            resetSuppress()
+          }}
+        >
+          <DropdownField
+            label="Pays de résidence"
+            placeholder="Sélectionnez un pays"
+            selected={values.country}
+            onSelect={(option) => {
               resetSuppress()
+              updateValue("country", option)
               markTouched({ country: true })
-            }
-          }}
-          success={successMessages.country}
-        />
-      </div>
+            }}
+            options={Array.from(COUNTRIES).map((country) => ({
+              value: country,
+              label: country,
+            }))}
+            touched={latchedTouched.country}
+            setTouched={(isTouched) => {
+              if (isTouched) {
+                resetSuppress()
+                markTouched({ country: true })
+              }
+            }}
+            success={successMessages.country}
+          />
+        </div>
+      </MissingField>
 
-      <ToggleField
-        label="Années de pratique"
-        value={values.experience}
-        options={Array.from(EXPERIENCE_OPTIONS)}
-        onChange={(option) => {
-          resetSuppress()
-          updateValue("experience", option)
-          markTouched({ experience: true })
-        }}
-        touched={latchedTouched.experience}
-        setTouched={() => {
-          resetSuppress()
-          markTouched({ experience: true })
-        }}
-        success={successMessages.experience}
-        variant="boxed"
-      />
-
-      <div
-        onMouseDown={() => {
-          resetSuppress()
-        }}
-      >
-        <DropdownField
-          label="Objectif principal"
-          placeholder="Sélectionnez un objectif"
-          selected={values.mainGoal}
-          onSelect={(option) => {
+      <MissingField show={missing.experience}>
+        <ToggleField
+          label="Années de pratique"
+          value={values.experience}
+          options={Array.from(EXPERIENCE_OPTIONS)}
+          onChange={(option) => {
             resetSuppress()
-            updateValue("mainGoal", option)
-            markTouched({ mainGoal: true })
+            updateValue("experience", option)
+            markTouched({ experience: true })
           }}
-          options={Array.from(MAIN_GOALS).map((goal) => ({ value: goal, label: goal }))}
-          touched={latchedTouched.mainGoal}
-          setTouched={(isTouched) => {
-            if (isTouched) {
-              resetSuppress()
-              markTouched({ mainGoal: true })
-            }
+          touched={latchedTouched.experience}
+          setTouched={() => {
+            resetSuppress()
+            markTouched({ experience: true })
           }}
-          success={successMessages.mainGoal}
+          success={successMessages.experience}
+          variant="boxed"
         />
-      </div>
+      </MissingField>
 
-      <ToggleField
-        label="Lieu d’entraînement"
-        value={values.trainingPlace}
-        options={Array.from(TRAINING_PLACES)}
-        onChange={(option) => {
-          resetSuppress()
-          updateValue("trainingPlace", option)
-          markTouched({ trainingPlace: true })
-        }}
-        touched={latchedTouched.trainingPlace}
-        setTouched={() => {
-          resetSuppress()
-          markTouched({ trainingPlace: true })
-        }}
-        success={successMessages.trainingPlace}
-      />
+      <MissingField show={missing.mainGoal}>
+        <div
+          onMouseDown={() => {
+            resetSuppress()
+          }}
+        >
+          <DropdownField
+            label="Objectif principal"
+            placeholder="Sélectionnez un objectif"
+            selected={values.mainGoal}
+            onSelect={(option) => {
+              resetSuppress()
+              updateValue("mainGoal", option)
+              markTouched({ mainGoal: true })
+            }}
+            options={Array.from(MAIN_GOALS).map((goal) => ({ value: goal, label: goal }))}
+            touched={latchedTouched.mainGoal}
+            setTouched={(isTouched) => {
+              if (isTouched) {
+                resetSuppress()
+                markTouched({ mainGoal: true })
+              }
+            }}
+            success={successMessages.mainGoal}
+          />
+        </div>
+      </MissingField>
 
-      <ToggleField
-        label="Nombre de séances par semaine"
-        value={values.weeklySessions}
-        options={Array.from(WEEKLY_SESSIONS_OPTIONS)}
-        onChange={(option) => {
-          resetSuppress()
-          updateValue("weeklySessions", option)
-          markTouched({ weeklySessions: true })
-        }}
-        touched={latchedTouched.weeklySessions}
-        setTouched={() => {
-          resetSuppress()
-          markTouched({ weeklySessions: true })
-        }}
-        success={successMessages.weeklySessions}
-        variant="boxed"
-      />
+      <MissingField show={missing.trainingPlace}>
+        <ToggleField
+          label="Lieu d’entraînement"
+          value={values.trainingPlace}
+          options={Array.from(TRAINING_PLACES)}
+          onChange={(option) => {
+            resetSuppress()
+            updateValue("trainingPlace", option)
+            markTouched({ trainingPlace: true })
+          }}
+          touched={latchedTouched.trainingPlace}
+          setTouched={() => {
+            resetSuppress()
+            markTouched({ trainingPlace: true })
+          }}
+          success={successMessages.trainingPlace}
+        />
+      </MissingField>
 
-      <ToggleField
-        label="Prise de compléments alimentaires"
-        value={values.supplements}
-        options={Array.from(SUPPLEMENTS_OPTIONS)}
-        onChange={(option) => {
-          resetSuppress()
-          updateValue("supplements", option)
-          markTouched({ supplements: true })
-        }}
-        touched={latchedTouched.supplements}
-        setTouched={() => {
-          resetSuppress()
-          markTouched({ supplements: true })
-        }}
-        success={successMessages.supplements}
-        className="w-[246px]"
-      />
+      <MissingField show={missing.weeklySessions}>
+        <ToggleField
+          label="Nombre de séances par semaine"
+          value={values.weeklySessions}
+          options={Array.from(WEEKLY_SESSIONS_OPTIONS)}
+          onChange={(option) => {
+            resetSuppress()
+            updateValue("weeklySessions", option)
+            markTouched({ weeklySessions: true })
+          }}
+          touched={latchedTouched.weeklySessions}
+          setTouched={() => {
+            resetSuppress()
+            markTouched({ weeklySessions: true })
+          }}
+          success={successMessages.weeklySessions}
+          variant="boxed"
+        />
+      </MissingField>
+
+      <MissingField show={missing.supplements}>
+        <ToggleField
+          label="Prise de compléments alimentaires"
+          value={values.supplements}
+          options={Array.from(SUPPLEMENTS_OPTIONS)}
+          onChange={(option) => {
+            resetSuppress()
+            updateValue("supplements", option)
+            markTouched({ supplements: true })
+          }}
+          touched={latchedTouched.supplements}
+          setTouched={() => {
+            resetSuppress()
+            markTouched({ supplements: true })
+          }}
+          success={successMessages.supplements}
+          className="w-[246px]"
+        />
+      </MissingField>
 
       <SubmitButton loading={loading} disabled={!hasChanges || loading} />
     </form>

--- a/src/components/account/fields/MissingField.tsx
+++ b/src/components/account/fields/MissingField.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import Image from 'next/image'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+
+type MissingFieldProps = {
+  show: boolean
+  children: ReactNode
+  /** largeur visuelle du champ (pour caler le wrapper) */
+  widthPx?: number
+  /** taille de l'icône */
+  iconSize?: number
+  /** écart entre le bord du champ et l'icône (px) */
+  gapPx?: number
+}
+
+/**
+ * Place une icône "missing" 10px à gauche du contrôle principal (input/select/toggle)
+ * sans impacter la mise en page. Aucun changement requis dans les composants de champ.
+ */
+export default function MissingField({
+  show,
+  children,
+  widthPx = 368,
+  iconSize = 24,
+  gapPx = 10,
+}: MissingFieldProps) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [topPx, setTopPx] = useState<number | null>(null)
+
+  const compute = () => {
+    const root = wrapRef.current
+    if (!root) return
+
+    const candidates = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'input, select, textarea, button, [role="button"], [data-control], [data-field-root], div, span'
+      )
+    )
+
+    let best: HTMLElement | null = null
+    for (const el of candidates) {
+      const rect = el.getBoundingClientRect()
+      const { height, width } = rect
+      if (height >= 40 && width >= 120) {
+        best = el
+        break
+      }
+    }
+
+    const rWrap = root.getBoundingClientRect()
+    const centerWrap = rWrap.top + rWrap.height / 2
+
+    if (!best) {
+      setTopPx(centerWrap - rWrap.top)
+      return
+    }
+
+    const rBest = best.getBoundingClientRect()
+    const centerBest = rBest.top + rBest.height / 2
+    setTopPx(centerBest - rWrap.top)
+  }
+
+  useLayoutEffect(() => {
+    compute()
+  }, [])
+
+  useEffect(() => {
+    if (!wrapRef.current) return
+    compute()
+
+    const observer = new ResizeObserver(() => compute())
+    observer.observe(wrapRef.current)
+
+    const firstChild = wrapRef.current.firstElementChild
+    if (firstChild) {
+      observer.observe(firstChild)
+    }
+
+    const onResize = () => compute()
+    const onScroll = () => compute()
+
+    window.addEventListener('resize', onResize)
+    window.addEventListener('scroll', onScroll, true)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('scroll', onScroll, true)
+    }
+  }, [])
+
+  return (
+    <div ref={wrapRef} className="relative" style={{ width: widthPx }}>
+      {children}
+
+      {show && topPx !== null && (
+        <span
+          className="absolute"
+          style={{
+            left: -(iconSize + gapPx),
+            top: topPx,
+            transform: 'translateY(-50%)',
+          }}
+          aria-hidden="true"
+        >
+          <Image src="/icons/missing.svg" alt="" width={iconSize} height={iconSize} />
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add an incomplete-profile alert banner to the account information form
- show a missing indicator beside each profile field that still needs to be completed
- include the reusable missing-field wrapper and icon asset used by the form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e288e7e27c832eb997a5628b07d2d9