### PR TITLE
Fix accordion overflow clipping missing-field icons

### DIFF
--- a/src/components/account/AccountAccordionSection.tsx
+++ b/src/components/account/AccountAccordionSection.tsx
@@ -13,8 +13,10 @@ type Props = {
 export default function AccountAccordionSection({ value, title, children }: Props) {
   return (
     <AccordionItem value={value}>
-      <div className="shadow-glift border border-[#ECE9F1] bg-white rounded-[5px] overflow-hidden">
-        <AccordionTrigger>{title}</AccordionTrigger>
+      <div className="shadow-glift border border-[#ECE9F1] bg-white rounded-[5px]">
+        <div className="overflow-hidden rounded-[5px]">
+          <AccordionTrigger>{title}</AccordionTrigger>
+        </div>
         <AccordionContent className="px-4 py-4 bg-white border-t border-[#ECE9F1] rounded-b-[5px]">
           {children}
         </AccordionContent>


### PR DESCRIPTION
## Summary
- remove the outer overflow clipping from the account accordion card so missing-field icons can render outside the card
- keep the trigger styling contained with an internal overflow-hidden wrapper that preserves the rounded card appearance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e28e7b503c832e8b0e9291c31ae0f0