### PR TITLE
Add profile completion success banner

### DIFF
--- a/src/components/account/IncompleteAlert.tsx
+++ b/src/components/account/IncompleteAlert.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 
 export default function IncompleteAlert() {
   return (
-    <div className="w-[564px] max-w-full mt-4">
+    <div className="w-[564px] max-w-full mt-4 mb-[30px]">
       <div className="relative bg-[#F4F5FE] rounded-[5px] px-5 py-2.5 text-left">
         <span className="absolute left-0 top-0 h-full w-[3px] bg-[#A1A5FD]" />
         <h3 className="text-[#7069FA] font-bold text-[12px]">Complétez votre profil</h3>

--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import type { User } from "@supabase/supabase-js"
 
 import {
@@ -19,6 +20,7 @@ import SubmitButton from "./fields/SubmitButton"
 import TextField from "./fields/TextField"
 import ToggleField from "./fields/ToggleField"
 import IncompleteAlert from "./IncompleteAlert"
+import ProfileCompleteAlert from "./ProfileCompleteAlert"
 import MissingField from "./fields/MissingField"
 
 export default function MesInformationsForm({ user }: { user: User | null }) {
@@ -39,6 +41,8 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
     endNameEdition,
   } = useAccountForm(user)
 
+  const [showSuccessBanner, setShowSuccessBanner] = useState(false)
+
   const trimmedName = values.name.trim()
   const missing = {
     gender: !values.gender,
@@ -58,11 +62,27 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
 
   const hasIncomplete = Object.values(missing).some(Boolean)
 
+  useEffect(() => {
+    if (hasIncomplete) {
+      setShowSuccessBanner(false)
+    }
+  }, [hasIncomplete])
+
+  useEffect(() => {
+    if (hasChanges) {
+      setShowSuccessBanner(false)
+    }
+  }, [hasChanges])
+
   return (
     <form
-      onSubmit={(event) => {
+      onSubmit={async (event) => {
         event.preventDefault()
-        handleSubmit()
+        setShowSuccessBanner(false)
+        const submitSucceeded = await handleSubmit()
+        if (submitSucceeded && !hasIncomplete) {
+          setShowSuccessBanner(true)
+        }
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
@@ -77,7 +97,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
         </div>
       )}
 
-      {hasIncomplete && <IncompleteAlert />}
+      {hasIncomplete ? <IncompleteAlert /> : showSuccessBanner ? <ProfileCompleteAlert /> : null}
 
       <MissingField show={missing.gender}>
         <ToggleField

--- a/src/components/account/ProfileCompleteAlert.tsx
+++ b/src/components/account/ProfileCompleteAlert.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+export default function ProfileCompleteAlert() {
+  return (
+    <div className="w-[564px] max-w-full mt-4 mb-[30px]">
+      <div className="relative rounded-[5px] bg-[#E6FAF0] px-5 py-2.5 text-left">
+        <span className="absolute left-0 top-0 h-full w-[3px] bg-[#34D399]" />
+        <h3 className="text-[12px] font-bold text-[#0F9D58]">Félicitations !</h3>
+        <p className="text-[12px] font-semibold leading-relaxed text-[#34D399]">
+          Votre profil est complet à 100% ! Nous allons pouvoir personnaliser encore plus votre
+          expérience avec Glift. N’hésitez pas à mettre régulièrement à jour vos informations.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/account/hooks/useAccountForm.ts
+++ b/src/components/account/hooks/useAccountForm.ts
@@ -448,7 +448,7 @@ export const useAccountForm = (user: User | null) => {
     )
   }, [currentFlat, initialFlat])
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(async (): Promise<boolean> => {
     resetFeedback()
     setLoading(true)
     setError(null)
@@ -474,9 +474,11 @@ export const useAccountForm = (user: User | null) => {
       setInitialBirthParts({ ...values.birthDate })
       successRef.current = {}
       setIsEditingName(false)
+      return true
     } catch (submitError) {
       console.error("Erreur mise à jour", submitError)
       setError(formatErrorMessage(submitError))
+      return false
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- add a success banner displayed after saving a fully completed profile
- ensure the informational banner and success banner have consistent spacing from form fields
- return submission success information from the account form hook to drive the banner state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29a83a040832ea57b1a4bdcbca082