### PR TITLE
Adjust success banner feedback styling and behavior

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -82,6 +82,9 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
         const submitSucceeded = await handleSubmit()
         if (submitSucceeded && !hasIncomplete) {
           setShowSuccessBanner(true)
+          if (typeof window !== "undefined") {
+            window.scrollTo({ top: 0, behavior: "smooth" })
+          }
         }
       }}
       onKeyDown={(event) => {

--- a/src/components/account/ProfileCompleteAlert.tsx
+++ b/src/components/account/ProfileCompleteAlert.tsx
@@ -3,10 +3,10 @@
 export default function ProfileCompleteAlert() {
   return (
     <div className="w-[564px] max-w-full mt-4 mb-[30px]">
-      <div className="relative rounded-[5px] bg-[#E6FAF0] px-5 py-2.5 text-left">
-        <span className="absolute left-0 top-0 h-full w-[3px] bg-[#34D399]" />
-        <h3 className="text-[12px] font-bold text-[#0F9D58]">Félicitations !</h3>
-        <p className="text-[12px] font-semibold leading-relaxed text-[#34D399]">
+      <div className="relative rounded-[5px] bg-[#E3F9E5] px-5 py-2.5 text-left">
+        <span className="absolute left-0 top-0 h-full w-[3px] bg-[#57AE5B]" />
+        <h3 className="text-[12px] font-bold text-[#207227]">Félicitations !</h3>
+        <p className="text-[12px] font-semibold leading-relaxed text-[#57AE5B]">
           Votre profil est complet à 100% ! Nous allons pouvoir personnaliser encore plus votre
           expérience avec Glift. N’hésitez pas à mettre régulièrement à jour vos informations.
         </p>


### PR DESCRIPTION
## Summary
- update the success banner on the Mes Informations form to use the requested brand colors
- scroll the page to the top once the form is successfully submitted with all required information

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29c58d408832ebf8379cfb68e6552