### PR TITLE
Add profile picture upload block to account form

### DIFF
--- a/src/components/account/fields/ProfilePictureBlock.tsx
+++ b/src/components/account/fields/ProfilePictureBlock.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useMemo, useRef, useState } from "react"
+import Image from "next/image"
+import { Camera, Trash2 } from "lucide-react"
+import Tooltip from "@/components/Tooltip"
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/avif",
+])
+
+type Props = {
+  imageUrl: string | null | undefined
+  profileCompletion: number
+  onImageChange: (file: File) => Promise<string> | string
+  onImageRemove: () => Promise<void> | void
+  isBusy?: boolean
+}
+
+const clampPercentage = (value: number) => {
+  if (!Number.isFinite(value)) return 0
+  if (value < 0) return 0
+  if (value > 100) return 100
+  return Math.round(value)
+}
+
+export default function ProfilePictureBlock({
+  imageUrl,
+  profileCompletion,
+  onImageChange,
+  onImageRemove,
+  isBusy = false,
+}: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [localBusy, setLocalBusy] = useState(false)
+
+  const working = isBusy || localBusy
+  const pct = useMemo(() => clampPercentage(profileCompletion), [profileCompletion])
+  const hasImage = Boolean(imageUrl && imageUrl.trim().length > 0)
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const input = event.currentTarget
+    const file = input.files?.[0]
+    if (!file) return
+
+    if (!ALLOWED_TYPES.has(file.type)) {
+      alert("Formats autorisés : JPG, PNG, WebP ou AVIF.")
+      input.value = ""
+      return
+    }
+
+    setLocalBusy(true)
+    try {
+      await onImageChange(file)
+    } catch (uploadError) {
+      console.error("Avatar upload failed", uploadError)
+    } finally {
+      setLocalBusy(false)
+      input.value = ""
+    }
+  }
+
+  const openFileDialog = () => {
+    if (working) return
+    fileInputRef.current?.click()
+  }
+
+  const handleRemove = async () => {
+    if (working || !hasImage) return
+    setLocalBusy(true)
+    try {
+      await onImageRemove()
+    } catch (removeError) {
+      console.error("Avatar removal failed", removeError)
+    } finally {
+      setLocalBusy(false)
+    }
+  }
+
+  const SIZE = 100
+  const RADIUS = 46
+  const STROKE = 6
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      <div className="relative w-[368px] flex flex-col items-center mb-4">
+        <div className="relative w-[100px] h-[100px]">
+          <svg className="absolute inset-0" viewBox={`0 0 ${SIZE} ${SIZE}`} aria-hidden="true">
+            <circle
+              cx="50"
+              cy="50"
+              r={RADIUS}
+              stroke="#ECE9F1"
+              strokeWidth={STROKE}
+              fill="none"
+            />
+            <circle
+              cx="50"
+              cy="50"
+              r={RADIUS}
+              stroke="#33E1AC"
+              strokeWidth={STROKE}
+              fill="none"
+              pathLength={100}
+              strokeDasharray={100}
+              strokeDashoffset={100 - pct}
+              strokeLinecap="round"
+              transform="rotate(-90 50 50)"
+              style={{ transition: "stroke-dashoffset 300ms ease" }}
+            />
+          </svg>
+
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="relative w-[75px] h-[75px] rounded-full overflow-hidden bg-[#ECE9F1]">
+              {hasImage ? (
+                <Image
+                  key={imageUrl}
+                  src={imageUrl as string}
+                  alt="Photo de profil"
+                  fill
+                  className="object-cover"
+                  sizes="75px"
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <Tooltip
+          content={hasImage ? "Supprimer la photo" : "Aucune photo"}
+          placement="top"
+          offset={16}
+          delay={400}
+          disableHover={!hasImage || working}
+        >
+          <button
+            type="button"
+            onClick={handleRemove}
+            disabled={!hasImage || working}
+            aria-label="Supprimer la photo de profil"
+            className="absolute left-[-52px] top-1/2 -translate-y-1/2"
+          >
+            <span
+              className={`flex h-[46px] w-[46px] items-center justify-center rounded-full border ${
+                hasImage && !working
+                  ? "border-[#F3F2F7] bg-white hover:bg-[#F1EFF9]"
+                  : "border-[#E4E1EB] bg-[#F7F6FB]"
+              } shadow-[0px_4px_12px_rgba(112,105,250,0.08)] transition-colors`}
+            >
+              <Trash2
+                className={`h-5 w-5 ${
+                  hasImage && !working ? "text-[#7069FA]" : "text-[#C5C1D6]"
+                }`}
+                aria-hidden="true"
+              />
+            </span>
+          </button>
+        </Tooltip>
+
+        <Tooltip content="Charger une photo" placement="top" offset={16} delay={400} disableHover={working}>
+          <button
+            type="button"
+            onClick={openFileDialog}
+            disabled={working}
+            aria-label="Changer la photo de profil"
+            className="absolute right-[-52px] top-1/2 -translate-y-1/2"
+          >
+            <span
+              className={`flex h-[46px] w-[46px] items-center justify-center rounded-full border ${
+                working ? "border-[#E4E1EB] bg-[#F7F6FB]" : "border-[#F3F2F7] bg-white hover:bg-[#F1EFF9]"
+              } shadow-[0px_4px_12px_rgba(112,105,250,0.08)] transition-colors`}
+            >
+              <Camera
+                className={`h-5 w-5 ${working ? "text-[#C5C1D6]" : "text-[#7069FA]"}`}
+                aria-hidden="true"
+              />
+            </span>
+          </button>
+        </Tooltip>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          accept="image/png,image/jpeg,image/webp,image/avif"
+          onChange={handleFileChange}
+          disabled={working}
+        />
+      </div>
+
+      <p className="text-base font-semibold text-[#3A416F]">
+        Votre profil est complet à{" "}
+        <span className="inline-flex w-[5ch] tabular-nums text-left justify-start">
+          <span className="text-[#33E1AC]">{pct}%</span>
+          <span className="text-[#3A416F]">.</span>
+        </span>
+      </p>
+    </div>
+  )
+}

--- a/src/components/account/hooks/useAvatar.ts
+++ b/src/components/account/hooks/useAvatar.ts
@@ -1,0 +1,249 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { User } from "@supabase/supabase-js"
+
+import { createClient } from "@/lib/supabaseClient"
+
+const DEFAULT_BUCKET = "avatars"
+
+const toStringOrNull = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  return null
+}
+
+const sanitizeExtension = (file: File) => {
+  const segments = file.name.split(".")
+  if (segments.length <= 1) return "png"
+  const extension = segments.pop() ?? ""
+  const normalized = extension.toLowerCase().replace(/[^a-z0-9]/g, "")
+  return normalized || "png"
+}
+
+type AvatarState = {
+  url: string | null
+  path: string | null
+}
+
+type UseAvatarResult = {
+  avatarUrl: string | null
+  displayUrl: string | null
+  isWorking: boolean
+  error: string | null
+  uploadAvatar: (file: File) => Promise<string>
+  removeAvatar: () => Promise<void>
+}
+
+const formatErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return fallback
+}
+
+const extractInitialState = (
+  metadata: Record<string, unknown> | undefined,
+): AvatarState => ({
+  url: toStringOrNull(metadata?.avatar_url),
+  path: toStringOrNull(metadata?.avatar_path),
+})
+
+export const useAvatar = (user: User | null): UseAvatarResult => {
+  const supabase = useMemo(() => createClient(), [])
+  const initialState = useMemo(
+    () => extractInitialState(user?.user_metadata as Record<string, unknown> | undefined),
+    [user?.user_metadata],
+  )
+
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(initialState.url)
+  const [avatarPath, setAvatarPath] = useState<string | null>(initialState.path)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const previewRef = useRef<string | null>(null)
+  const [isWorking, setIsWorking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const bucket = process.env.NEXT_PUBLIC_SUPABASE_AVATARS_BUCKET?.trim() || DEFAULT_BUCKET
+
+  const releasePreview = useCallback((candidate: string | null) => {
+    if (!candidate || !candidate.startsWith("blob:")) return
+    try {
+      URL.revokeObjectURL(candidate)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  useEffect(() => {
+    setAvatarUrl(initialState.url)
+    setAvatarPath(initialState.path)
+  }, [initialState.path, initialState.url])
+
+  useEffect(() => {
+    return () => {
+      releasePreview(previewRef.current)
+    }
+  }, [releasePreview])
+
+  const uploadAvatar = useCallback(
+    async (file: File) => {
+      if (!user?.id) {
+        const message = "Vous devez être connecté pour modifier votre photo."
+        setError(message)
+        throw new Error(message)
+      }
+
+      if (isWorking) {
+        return avatarUrl ?? ""
+      }
+
+      const nextPreview = URL.createObjectURL(file)
+      if (previewRef.current && previewRef.current !== nextPreview) {
+        releasePreview(previewRef.current)
+      }
+
+      previewRef.current = nextPreview
+      setPreviewUrl(nextPreview)
+      setIsWorking(true)
+      setError(null)
+
+      try {
+        const extension = sanitizeExtension(file)
+        const objectPath = `${user.id}/${Date.now()}-${Math.random().toString(36).slice(2)}.${extension}`
+
+        const { error: uploadError } = await supabase.storage
+          .from(bucket)
+          .upload(objectPath, file, { cacheControl: "3600", upsert: true })
+
+        if (uploadError) {
+          throw uploadError
+        }
+
+        const { data: publicUrlData, error: publicUrlError } = supabase.storage
+          .from(bucket)
+          .getPublicUrl(objectPath)
+
+        if (publicUrlError) {
+          throw publicUrlError
+        }
+
+        const publicUrl = publicUrlData?.publicUrl
+        if (!publicUrl) {
+          throw new Error("Impossible de récupérer l'URL de la photo.")
+        }
+
+        const { error: updateError } = await supabase.auth.updateUser({
+          data: {
+            avatar_url: publicUrl,
+            avatar_path: objectPath,
+          },
+        })
+
+        if (updateError) {
+          throw updateError
+        }
+
+        const previousPath = avatarPath
+        setAvatarUrl(publicUrl)
+        setAvatarPath(objectPath)
+        setError(null)
+
+        if (previousPath && previousPath !== objectPath) {
+          void supabase.storage
+            .from(bucket)
+            .remove([previousPath])
+            .catch(() => {
+              // best-effort cleanup
+            })
+        }
+
+        return publicUrl
+      } catch (uploadError) {
+        setError(
+          formatErrorMessage(
+            uploadError,
+            "Impossible de charger la photo. Veuillez réessayer.",
+          ),
+        )
+        throw uploadError
+      } finally {
+        setIsWorking(false)
+        setPreviewUrl(null)
+        releasePreview(previewRef.current)
+        previewRef.current = null
+      }
+    },
+    [avatarPath, avatarUrl, bucket, isWorking, releasePreview, supabase, user?.id],
+  )
+
+  const removeAvatar = useCallback(async () => {
+    if (isWorking) {
+      return
+    }
+
+    if (!user?.id) {
+      const message = "Vous devez être connecté pour modifier votre photo."
+      setError(message)
+      throw new Error(message)
+    }
+
+    setIsWorking(true)
+    setError(null)
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        data: {
+          avatar_url: null,
+          avatar_path: null,
+        },
+      })
+
+      if (updateError) {
+        throw updateError
+      }
+
+      const pathToRemove = avatarPath
+      setAvatarUrl(null)
+      setAvatarPath(null)
+      setPreviewUrl(null)
+
+      if (pathToRemove) {
+        await supabase.storage
+          .from(bucket)
+          .remove([pathToRemove])
+          .catch(() => {
+            // ignore cleanup failure
+          })
+      }
+    } catch (removeError) {
+      setError(
+        formatErrorMessage(
+          removeError,
+          "Impossible de supprimer la photo actuellement. Veuillez réessayer.",
+        ),
+      )
+      throw removeError
+    } finally {
+      setIsWorking(false)
+      releasePreview(previewRef.current)
+      previewRef.current = null
+    }
+  }, [avatarPath, bucket, isWorking, releasePreview, supabase, user?.id])
+
+  const displayUrl = previewUrl ?? avatarUrl
+
+  return {
+    avatarUrl,
+    displayUrl,
+    isWorking,
+    error,
+    uploadAvatar,
+    removeAvatar,
+  }
+}
+
+export type { UseAvatarResult }


### PR DESCRIPTION
## Summary
- add a profile picture block above the Sexe field with completion progress
- introduce a Supabase-based avatar hook and UI component to upload or delete the photo
- include the avatar in the profile completion calculation and surface upload errors to the form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29ed50158832e84edaa3dd0bbbce6