### PR TITLE
Update avatar block spacing and icon presentation

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -89,6 +89,9 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
   const profileCompletion = Math.round(completionRatio * 100)
 
   const hasIncomplete = Object.values(missing).some(Boolean)
+  const hasTopMessage = Boolean(
+    error || avatarError || hasIncomplete || showSuccessBanner,
+  )
 
   useEffect(() => {
     if (hasIncomplete) {
@@ -136,7 +139,11 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
 
       {hasIncomplete ? <IncompleteAlert /> : showSuccessBanner ? <ProfileCompleteAlert /> : null}
 
-      <div className="w-[368px] flex flex-col items-center mb-[30px]">
+      <div
+        className={`w-[368px] flex flex-col items-center mb-[30px]${
+          hasTopMessage ? "" : " mt-[30px]"
+        }`}
+      >
         <ProfilePictureBlock
           imageUrl={avatarDisplayUrl}
           profileCompletion={profileCompletion}

--- a/src/components/account/fields/ProfilePictureBlock.tsx
+++ b/src/components/account/fields/ProfilePictureBlock.tsx
@@ -101,36 +101,32 @@ export default function ProfilePictureBlock({
               onClick={handleRemove}
               disabled={!isDeleteEnabled}
               aria-label="Supprimer la photo de profil"
-              className="group relative"
+              className={`group relative inline-flex h-5 w-5 items-center justify-center ${
+                isDeleteEnabled ? "cursor-pointer" : "cursor-not-allowed"
+              }`}
             >
-              <span
-                className={`relative flex h-[46px] w-[46px] items-center justify-center rounded-full border ${
+              <Image
+                src="/icons/delete_photo.svg"
+                alt=""
+                width={20}
+                height={20}
+                className={
                   isDeleteEnabled
-                    ? "border-[#F3F2F7] bg-white group-hover:bg-[#F1EFF9]"
-                    : "border-[#E4E1EB] bg-[#F7F6FB]"
-                } shadow-[0px_4px_12px_rgba(112,105,250,0.08)] transition-colors`}
-              >
+                    ? "transition-opacity group-hover:opacity-0"
+                    : undefined
+                }
+                aria-hidden="true"
+              />
+              {isDeleteEnabled ? (
                 <Image
-                  src="/icons/delete_photo.svg"
+                  src="/icons/delete_photo_hover.svg"
                   alt=""
                   width={20}
                   height={20}
-                  className={`${
-                    isDeleteEnabled ? "transition-opacity group-hover:opacity-0" : "opacity-40"
-                  }`}
+                  className="absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100"
                   aria-hidden="true"
                 />
-                {isDeleteEnabled ? (
-                  <Image
-                    src="/icons/delete_photo_hover.svg"
-                    alt=""
-                    width={20}
-                    height={20}
-                    className="absolute inset-0 m-auto transition-opacity opacity-0 group-hover:opacity-100"
-                    aria-hidden="true"
-                  />
-                ) : null}
-              </span>
+              ) : null}
             </button>
           </Tooltip>
 
@@ -188,36 +184,32 @@ export default function ProfilePictureBlock({
               onClick={openFileDialog}
               disabled={!isUploadEnabled}
               aria-label="Changer la photo de profil"
-              className="group relative"
+              className={`group relative inline-flex h-5 w-5 items-center justify-center ${
+                isUploadEnabled ? "cursor-pointer" : "cursor-not-allowed"
+              }`}
             >
-              <span
-                className={`relative flex h-[46px] w-[46px] items-center justify-center rounded-full border ${
+              <Image
+                src="/icons/photo.svg"
+                alt=""
+                width={20}
+                height={20}
+                className={
                   isUploadEnabled
-                    ? "border-[#F3F2F7] bg-white group-hover:bg-[#F1EFF9]"
-                    : "border-[#E4E1EB] bg-[#F7F6FB]"
-                } shadow-[0px_4px_12px_rgba(112,105,250,0.08)] transition-colors`}
-              >
+                    ? "transition-opacity group-hover:opacity-0"
+                    : undefined
+                }
+                aria-hidden="true"
+              />
+              {isUploadEnabled ? (
                 <Image
-                  src="/icons/photo.svg"
+                  src="/icons/photo_hover.svg"
                   alt=""
                   width={20}
                   height={20}
-                  className={`${
-                    isUploadEnabled ? "transition-opacity group-hover:opacity-0" : "opacity-40"
-                  }`}
+                  className="absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100"
                   aria-hidden="true"
                 />
-                {isUploadEnabled ? (
-                  <Image
-                    src="/icons/photo_hover.svg"
-                    alt=""
-                    width={20}
-                    height={20}
-                    className="absolute inset-0 m-auto transition-opacity opacity-0 group-hover:opacity-100"
-                    aria-hidden="true"
-                  />
-                ) : null}
-              </span>
+              ) : null}
             </button>
           </Tooltip>
         </div>


### PR DESCRIPTION
## Summary
- add conditional top margin so the avatar block has breathing room when no alerts are shown
- restyle avatar action buttons to show bare icons and use a not-allowed cursor for disabled states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b3b5cf24832e82a8d3dc237e68a3