### PR TITLE
Improve avatar actions tooltip and hover interactions

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -31,6 +31,13 @@ export default function Tooltip({
   const tooltipRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  const clearDelayTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
@@ -39,14 +46,10 @@ export default function Tooltip({
   useEffect(() => {
     if (!disableHover) return;
 
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-
+    clearDelayTimeout();
     setVisible(false);
     setReady(false);
-  }, [disableHover]);
+  }, [clearDelayTimeout, disableHover]);
 
   const calculatePosition = useCallback(() => {
     if (!triggerRef.current || !tooltipRef.current) return;
@@ -74,13 +77,14 @@ export default function Tooltip({
     }, delay);
   };
 
-  const handleMouseLeave = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
+  const hideTooltip = useCallback(() => {
+    clearDelayTimeout();
     setVisible(false);
     setReady(false);
+  }, [clearDelayTimeout]);
+
+  const handleMouseLeave = () => {
+    hideTooltip();
   };
 
   useEffect(() => {
@@ -97,6 +101,7 @@ export default function Tooltip({
         ref={triggerRef}
         onMouseEnter={disableHover ? undefined : handleMouseEnter}
         onMouseLeave={disableHover ? undefined : handleMouseLeave}
+        onClick={hideTooltip}
         className="inline-flex items-center"
       >
         {children}

--- a/src/components/account/fields/ProfilePictureBlock.tsx
+++ b/src/components/account/fields/ProfilePictureBlock.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import Image from "next/image"
 import Tooltip from "@/components/Tooltip"
 
@@ -35,12 +35,26 @@ export default function ProfilePictureBlock({
 }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [localBusy, setLocalBusy] = useState(false)
+  const [isDeleteHovered, setIsDeleteHovered] = useState(false)
+  const [isUploadHovered, setIsUploadHovered] = useState(false)
 
   const working = isBusy || localBusy
   const pct = useMemo(() => clampPercentage(profileCompletion), [profileCompletion])
   const hasImage = Boolean(imageUrl && imageUrl.trim().length > 0)
   const isDeleteEnabled = hasImage && !working
   const isUploadEnabled = !working
+
+  useEffect(() => {
+    if (!isDeleteEnabled) {
+      setIsDeleteHovered(false)
+    }
+  }, [isDeleteEnabled])
+
+  useEffect(() => {
+    if (!isUploadEnabled) {
+      setIsUploadHovered(false)
+    }
+  }, [isUploadEnabled])
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const input = event.currentTarget
@@ -101,29 +115,31 @@ export default function ProfilePictureBlock({
               onClick={handleRemove}
               disabled={!isDeleteEnabled}
               aria-label="Supprimer la photo de profil"
-              className={`group relative inline-flex h-[25px] w-[23px] items-center justify-center ${
+              onMouseEnter={isDeleteEnabled ? () => setIsDeleteHovered(true) : undefined}
+              onMouseLeave={() => setIsDeleteHovered(false)}
+              className={`group relative inline-flex h-[28px] w-[25px] items-center justify-center ${
                 isDeleteEnabled ? "cursor-pointer" : "cursor-not-allowed"
               }`}
             >
               <Image
                 src="/icons/delete_photo.svg"
                 alt=""
-                width={23}
-                height={25}
-                className={
-                  isDeleteEnabled
-                    ? "transition-opacity group-hover:opacity-0"
-                    : undefined
-                }
+                width={25}
+                height={28}
+                className={`transition-opacity duration-150 ${
+                  isDeleteHovered ? "opacity-0" : "opacity-100"
+                }`}
                 aria-hidden="true"
               />
               {isDeleteEnabled ? (
                 <Image
                   src="/icons/delete_photo_hover.svg"
                   alt=""
-                  width={23}
-                  height={25}
-                  className="absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100"
+                  width={25}
+                  height={28}
+                  className={`absolute inset-0 m-auto transition-opacity duration-150 ${
+                    isDeleteHovered ? "opacity-100" : "opacity-0"
+                  }`}
                   aria-hidden="true"
                 />
               ) : null}
@@ -183,6 +199,8 @@ export default function ProfilePictureBlock({
               onClick={openFileDialog}
               disabled={!isUploadEnabled}
               aria-label="Changer la photo de profil"
+              onMouseEnter={isUploadEnabled ? () => setIsUploadHovered(true) : undefined}
+              onMouseLeave={() => setIsUploadHovered(false)}
               className={`group relative inline-flex h-[25px] w-[28px] items-center justify-center ${
                 isUploadEnabled ? "cursor-pointer" : "cursor-not-allowed"
               }`}
@@ -192,11 +210,9 @@ export default function ProfilePictureBlock({
                 alt=""
                 width={28}
                 height={25}
-                className={
-                  isUploadEnabled
-                    ? "transition-opacity group-hover:opacity-0"
-                    : undefined
-                }
+                className={`transition-opacity duration-150 ${
+                  isUploadHovered ? "opacity-0" : "opacity-100"
+                }`}
                 aria-hidden="true"
               />
               {isUploadEnabled ? (
@@ -205,7 +221,9 @@ export default function ProfilePictureBlock({
                   alt=""
                   width={28}
                   height={25}
-                  className="absolute inset-0 m-auto opacity-0 transition-opacity group-hover:opacity-100"
+                  className={`absolute inset-0 m-auto transition-opacity duration-150 ${
+                    isUploadHovered ? "opacity-100" : "opacity-0"
+                  }`}
                   aria-hidden="true"
                 />
               ) : null}


### PR DESCRIPTION
## Summary
- enlarge the delete avatar icon to the requested size
- manage avatar action hover transitions so they reset immediately when the pointer leaves
- hide the tooltip as soon as the trigger is clicked to avoid lingering overlays

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2bdac85a8832e8307ebc282b0be1f