### PR TITLE
Fix avatar hover state and delete icon size

### DIFF
--- a/src/components/account/fields/ProfilePictureBlock.tsx
+++ b/src/components/account/fields/ProfilePictureBlock.tsx
@@ -80,6 +80,7 @@ export default function ProfilePictureBlock({
 
   const openFileDialog = () => {
     if (working) return
+    setIsUploadHovered(false)
     fileInputRef.current?.click()
   }
 
@@ -117,14 +118,14 @@ export default function ProfilePictureBlock({
               aria-label="Supprimer la photo de profil"
               onMouseEnter={isDeleteEnabled ? () => setIsDeleteHovered(true) : undefined}
               onMouseLeave={() => setIsDeleteHovered(false)}
-              className={`group relative inline-flex h-[28px] w-[25px] items-center justify-center ${
+              className={`group relative inline-flex h-[28px] w-[28px] items-center justify-center ${
                 isDeleteEnabled ? "cursor-pointer" : "cursor-not-allowed"
               }`}
             >
               <Image
                 src="/icons/delete_photo.svg"
                 alt=""
-                width={25}
+                width={28}
                 height={28}
                 className={`transition-opacity duration-150 ${
                   isDeleteHovered ? "opacity-0" : "opacity-100"
@@ -135,7 +136,7 @@ export default function ProfilePictureBlock({
                 <Image
                   src="/icons/delete_photo_hover.svg"
                   alt=""
-                  width={25}
+                  width={28}
                   height={28}
                   className={`absolute inset-0 m-auto transition-opacity duration-150 ${
                     isDeleteHovered ? "opacity-100" : "opacity-0"


### PR DESCRIPTION
## Summary
- prevent the photo upload control from remaining in its hover state while the file picker is open
- ensure the delete avatar icon renders at 28px by aligning its dimensions with the button container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c0692f5c832ebf4e2d39d4cb56da