### PR TITLE
Synchronize avatar between profile and header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,6 +20,15 @@ export default function Header({ disconnected = false }: HeaderProps) {
   const [isSticky, setIsSticky] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  const rawAvatarUrl =
+    typeof user?.user_metadata?.avatar_url === "string"
+      ? user.user_metadata.avatar_url.trim()
+      : "";
+  const hasAvatar = rawAvatarUrl.length > 0;
+  const userInitial =
+    user?.user_metadata?.name?.charAt(0).toUpperCase() || "?";
+  const userDisplayName = user?.user_metadata?.name?.trim() || "Profil";
+
   // Forcer le mode déconnecté si `disconnected` est vrai
   const showAuthenticatedUI = isAuthenticated && !isRecoverySession && !disconnected;
 
@@ -215,10 +224,20 @@ export default function Header({ disconnected = false }: HeaderProps) {
               onClick={() => setDropdownOpen(!dropdownOpen)}
               className="group flex items-center gap-2 text-[#5D6494] hover:text-[#3A416F] text-[16px] font-semibold"
             >
-              <div className="w-[44px] h-[44px] text-[25px] rounded-full bg-[#7069FA] text-white flex items-center justify-center font-semibold">
-                {user?.user_metadata?.name?.charAt(0).toUpperCase() || "?"}
+              <div className="w-[44px] h-[44px] text-[25px] rounded-full bg-[#7069FA] text-white flex items-center justify-center font-semibold overflow-hidden">
+                {hasAvatar ? (
+                  <Image
+                    src={rawAvatarUrl}
+                    alt={`Avatar de ${userDisplayName}`}
+                    width={44}
+                    height={44}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  userInitial
+                )}
               </div>
-              {user?.user_metadata?.name?.trim() || "Profil"}
+              {userDisplayName}
               <span
                 className={`relative w-[14px] h-[8px] mt-[2px] group transition-transform duration-200 ${
                   dropdownOpen ? "rotate-180" : ""

--- a/src/components/account/hooks/useAvatar.ts
+++ b/src/components/account/hooks/useAvatar.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { User } from "@supabase/supabase-js"
 
+import { useUser } from "@/context/UserContext"
 import { createClient } from "@/lib/supabaseClient"
 
 const DEFAULT_BUCKET = "avatars"
@@ -55,6 +56,7 @@ const extractInitialState = (
 
 export const useAvatar = (user: User | null): UseAvatarResult => {
   const supabase = useMemo(() => createClient(), [])
+  const { updateUserMetadata } = useUser()
   const initialState = useMemo(
     () => extractInitialState(user?.user_metadata as Record<string, unknown> | undefined),
     [user?.user_metadata],
@@ -151,6 +153,10 @@ export const useAvatar = (user: User | null): UseAvatarResult => {
         setAvatarUrl(publicUrl)
         setAvatarPath(objectPath)
         setError(null)
+        updateUserMetadata({
+          avatar_url: publicUrl,
+          avatar_path: objectPath,
+        })
 
         if (previousPath && previousPath !== objectPath) {
           void supabase.storage
@@ -177,7 +183,16 @@ export const useAvatar = (user: User | null): UseAvatarResult => {
         previewRef.current = null
       }
     },
-    [avatarPath, avatarUrl, bucket, isWorking, releasePreview, supabase, user?.id],
+    [
+      avatarPath,
+      avatarUrl,
+      bucket,
+      isWorking,
+      releasePreview,
+      supabase,
+      updateUserMetadata,
+      user?.id,
+    ],
   )
 
   const removeAvatar = useCallback(async () => {
@@ -210,6 +225,10 @@ export const useAvatar = (user: User | null): UseAvatarResult => {
       setAvatarUrl(null)
       setAvatarPath(null)
       setPreviewUrl(null)
+      updateUserMetadata({
+        avatar_url: null,
+        avatar_path: null,
+      })
 
       if (pathToRemove) {
         await supabase.storage
@@ -232,7 +251,15 @@ export const useAvatar = (user: User | null): UseAvatarResult => {
       releasePreview(previewRef.current)
       previewRef.current = null
     }
-  }, [avatarPath, bucket, isWorking, releasePreview, supabase, user?.id])
+  }, [
+    avatarPath,
+    bucket,
+    isWorking,
+    releasePreview,
+    supabase,
+    updateUserMetadata,
+    user?.id,
+  ])
 
   const displayUrl = previewUrl ?? avatarUrl
 


### PR DESCRIPTION
## Summary
- show the uploaded avatar in the header when available and fall back to initials otherwise
- persist avatar changes in the shared user context so the header and profile stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c1bd872c832e854e04a925bdd7ff