### PR TITLE
Adjust avatar styling to remove header border

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -224,14 +224,18 @@ export default function Header({ disconnected = false }: HeaderProps) {
               onClick={() => setDropdownOpen(!dropdownOpen)}
               className="group flex items-center gap-2 text-[#5D6494] hover:text-[#3A416F] text-[16px] font-semibold"
             >
-              <div className="w-[44px] h-[44px] text-[25px] rounded-full bg-[#7069FA] text-white flex items-center justify-center font-semibold overflow-hidden">
+              <div
+                className={`w-[44px] h-[44px] text-[25px] rounded-full text-white flex items-center justify-center font-semibold overflow-hidden ${
+                  hasAvatar ? "bg-transparent" : "bg-[#7069FA]"
+                }`}
+              >
                 {hasAvatar ? (
                   <Image
                     src={rawAvatarUrl}
                     alt={`Avatar de ${userDisplayName}`}
                     width={44}
                     height={44}
-                    className="w-full h-full object-cover"
+                    className="w-full h-full object-cover rounded-full border-0 outline-none"
                   />
                 ) : (
                   userInitial


### PR DESCRIPTION
## Summary
- ensure the avatar container uses a transparent background when a user image is present
- remove any residual border around the avatar image by enforcing borderless rounded styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c37dc67c832e9d2ec11f1ce8c08e