### PR TITLE
Ensure account submit CTA stays disabled while loading

### DIFF
--- a/src/components/account/fields/SubmitButton.tsx
+++ b/src/components/account/fields/SubmitButton.tsx
@@ -15,7 +15,7 @@ export default function SubmitButton({
   label = "Enregistrer mes informations",
   onClick,
 }: Props) {
-  const isDisabled = disabled && !loading;
+  const isDisabled = disabled || loading;
 
   return (
     <div className="w-full flex justify-center mt-3 mb-8">


### PR DESCRIPTION
## Summary
- ensure the account information submit button stays disabled when a submission is in progress

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e35f6eb4cc832e90f8883a2168a766