### PR TITLE
Fix avatar public URL retrieval typing

### DIFF
--- a/src/components/account/hooks/useAvatar.ts
+++ b/src/components/account/hooks/useAvatar.ts
@@ -125,15 +125,15 @@ export const useAvatar = (user: User | null): UseAvatarResult => {
           throw uploadError
         }
 
-        const { data: publicUrlData, error: publicUrlError } = supabase.storage
+        const { data: publicUrlData } = supabase.storage
           .from(bucket)
           .getPublicUrl(objectPath)
 
-        if (publicUrlError) {
-          throw publicUrlError
+        if (!publicUrlData) {
+          throw new Error("Impossible de récupérer l'URL de la photo.")
         }
 
-        const publicUrl = publicUrlData?.publicUrl
+        const publicUrl = publicUrlData.publicUrl
         if (!publicUrl) {
           throw new Error("Impossible de récupérer l'URL de la photo.")
         }


### PR DESCRIPTION
## Summary
- adjust avatar hook to match Supabase getPublicUrl response shape
- keep strong error handling when no URL is returned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3604918c4832eb6b6cd12db0ac69f