### PR TITLE
Enforce required first name in account form

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -54,6 +54,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
   const [showSuccessBanner, setShowSuccessBanner] = useState(false)
 
   const trimmedName = values.name.trim()
+  const nameError = trimmedName.length === 0 ? "Ce champ ne peut pas être vide." : undefined
   const missing = {
     gender: !values.gender,
     name: trimmedName.length === 0,
@@ -110,6 +111,10 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
       onSubmit={async (event) => {
         event.preventDefault()
         setShowSuccessBanner(false)
+        if (trimmedName.length === 0) {
+          markTouched({ name: true })
+          return
+        }
         const submitSucceeded = await handleSubmit()
         if (submitSucceeded && !hasIncomplete) {
           setShowSuccessBanner(true)
@@ -194,6 +199,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
             startNameEdition()
           }}
           success={successMessages.name}
+          error={nameError}
         />
       </MissingField>
 
@@ -380,7 +386,10 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
         />
       </MissingField>
 
-      <SubmitButton loading={loading} disabled={!hasChanges || loading} />
+      <SubmitButton
+        loading={loading}
+        disabled={!hasChanges || loading || trimmedName.length === 0}
+      />
     </form>
   )
 }

--- a/src/components/account/fields/TextField.tsx
+++ b/src/components/account/fields/TextField.tsx
@@ -11,6 +11,7 @@ type Props = {
   onFocus?: () => void
   disabled?: boolean
   success?: string
+  error?: string
   endAdornment?: ReactNode
 }
 
@@ -22,9 +23,11 @@ export default function TextField({
   onFocus,
   disabled = false,
   success,
+  error,
   endAdornment,
 }: Props) {
-  const showSuccess = !!success
+  const showError = !!error
+  const showSuccess = !!success && !showError
 
   return (
     <div className="w-[368px] flex flex-col text-left">
@@ -43,11 +46,11 @@ export default function TextField({
             ${disabled ? 'bg-[#F2F1F6] text-[#D7D4DC] cursor-not-allowed' : 'bg-white text-[#3A416F]'}
             transition-all duration-150
             border
-            ${
-              success
-                ? 'border-[#00D591]'
-                : 'border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]'
-            }
+            ${showError
+              ? 'border-[#EF4444] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#FCA5A5]'
+              : showSuccess
+              ? 'border-[#00D591]'
+              : 'border-[#D7D4DC] hover:border-[#C2BFC6] focus:outline-none focus:border-transparent focus:ring-2 focus:ring-[#A1A5FD]'}
           `}
           placeholder={label}
         />
@@ -65,7 +68,11 @@ export default function TextField({
       </div>
 
       <div className="h-[20px] mt-[5px] text-[13px] font-medium">
-        {showSuccess && <SuccessMsg>{success}</SuccessMsg>}
+        {showError ? (
+          <p className="text-[#EF4444]">{error}</p>
+        ) : showSuccess ? (
+          <SuccessMsg>{success}</SuccessMsg>
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/account/hooks/useAccountForm.ts
+++ b/src/components/account/hooks/useAccountForm.ts
@@ -243,7 +243,10 @@ const useSuccessMessages = (params: {
     }
 
     if (latchedTouched.country && values.country && values.country !== initialFlat.country) {
-      next.country = "Ok, c'est un beau pays !"
+      next.country =
+        values.country === "Autre"
+          ? "Ok, c'est noté."
+          : "Ok, c'est un beau pays !"
     } else {
       delete next.country
     }


### PR DESCRIPTION
## Summary
- block submission when the first name field is empty and display an inline validation message
- add error styling support to the shared text field component used by account forms
- adjust the country success feedback so selecting "Autre" uses the specific acknowledgement copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e361b23920832ea587d6d921264d53