### PR TITLE
Fix first name field error visibility

### DIFF
--- a/src/components/account/MesInformationsForm.tsx
+++ b/src/components/account/MesInformationsForm.tsx
@@ -41,6 +41,7 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
     initialBirthParts,
     startNameEdition,
     endNameEdition,
+    isEditingName,
   } = useAccountForm(user)
 
   const {
@@ -54,7 +55,10 @@ export default function MesInformationsForm({ user }: { user: User | null }) {
   const [showSuccessBanner, setShowSuccessBanner] = useState(false)
 
   const trimmedName = values.name.trim()
-  const nameError = trimmedName.length === 0 ? "Ce champ ne peut pas être vide." : undefined
+  const nameError =
+    trimmedName.length === 0 && !isEditingName
+      ? "Ce champ ne peut pas être vide."
+      : undefined
   const missing = {
     gender: !values.gender,
     name: trimmedName.length === 0,

--- a/src/components/account/hooks/useAccountForm.ts
+++ b/src/components/account/hooks/useAccountForm.ts
@@ -512,6 +512,7 @@ export const useAccountForm = (user: User | null) => {
     initialBirthParts,
     startNameEdition,
     endNameEdition,
+    isEditingName,
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the first name error message while the field is active
- expose the name editing state from `useAccountForm` to let the UI control when errors appear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e363e18c10832eaaa4590fb112e305