### PR TITLE
Affiche un loader global durant le chargement de l'utilisateur

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -4,9 +4,10 @@ import { usePathname } from "next/navigation";
 import Header from "@/components/Header";
 import AdminHeader from "@/components/AdminHeader";
 import Footer from "@/components/Footer";
-import { UserProvider } from "@/context/UserContext";
+import { useUser, UserProvider } from "@/context/UserContext";
 import SupabaseProvider from "@/components/SupabaseProvider";
 import AuthDebug from "@/components/AuthDebug";
+import GliftLoader from "@/components/ui/GliftLoader";
 
 interface ClientLayoutProps {
   children: React.ReactNode;
@@ -20,15 +21,44 @@ export default function ClientLayout({ children, disconnected = false }: ClientL
   return (
     <SupabaseProvider>
       <UserProvider>
-        {isAdminPage ? (
-          <AdminHeader />
-        ) : (
-          <Header disconnected={disconnected} />
-        )}
-        {children}
-        {!isAdminPage && <Footer />}
-        {process.env.NODE_ENV === "development" && <AuthDebug />}
+        <ClientLayoutContent
+          disconnected={disconnected}
+          isAdminPage={Boolean(isAdminPage)}
+        >
+          {children}
+        </ClientLayoutContent>
       </UserProvider>
     </SupabaseProvider>
+  );
+}
+
+interface ClientLayoutContentProps {
+  children: React.ReactNode;
+  disconnected: boolean;
+  isAdminPage: boolean;
+}
+
+function ClientLayoutContent({
+  children,
+  disconnected,
+  isAdminPage,
+}: ClientLayoutContentProps) {
+  const { isLoading } = useUser();
+
+  if (isLoading) {
+    return <GliftLoader />;
+  }
+
+  return (
+    <>
+      {isAdminPage ? (
+        <AdminHeader />
+      ) : (
+        <Header disconnected={disconnected} />
+      )}
+      {children}
+      {!isAdminPage && <Footer />}
+      {process.env.NODE_ENV === "development" && <AuthDebug />}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- affiche un loader plein écran tant que les données utilisateur sont en cours de récupération
- conserve ensuite l'affichage habituel (header/footer) une fois l'utilisateur chargé

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e36587f270832e99913f37f2587d66