### PR TITLE
Ensure loaders stay visible for a minimum duration

### DIFF
--- a/src/app/admin/create-offer/page.tsx
+++ b/src/app/admin/create-offer/page.tsx
@@ -9,6 +9,7 @@ import { AdminTextField } from "@/app/admin/components/AdminTextField";
 import AdminMultiSelectDropdown from "@/components/AdminMultiSelectDropdown";
 import CTAButton from "@/components/CTAButton";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 const days = Array.from({ length: 31 }, (_, i) => (i + 1).toString().padStart(2, "0"));
 const months = [
@@ -67,6 +68,7 @@ export default function CreateOfferPage() {
 
   const [offerId, setOfferId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const showLoader = useMinimumVisibility(loading);
 
   const [offer, setOffer] = useState<Omit<Offer, "id">>({
     start_date: "",
@@ -173,7 +175,7 @@ export default function CreateOfferPage() {
 
   return (
     <>
-      {loading && <GliftLoader />}
+      {showLoader && <GliftLoader />}
       <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
         <div className="w-full max-w-3xl">
           <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">

--- a/src/app/admin/create-program/page.tsx
+++ b/src/app/admin/create-program/page.tsx
@@ -7,6 +7,7 @@ import ImageUploader from "@/app/admin/components/ImageUploader";
 import AdminDropdown from "@/app/admin/components/AdminDropdown";
 import CTAButton from "@/components/CTAButton";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 type Program = {
   id?: number;
@@ -34,6 +35,7 @@ export default function CreateProgramPage() {
   const searchParams = useSearchParams();
 
   const [loading, setLoading] = useState(true);
+  const showLoader = useMinimumVisibility(loading);
   const [programId, setProgramId] = useState<string | null>(null);
 
   const [program, setProgram] = useState<Omit<Program, "id">>({
@@ -171,7 +173,7 @@ export default function CreateProgramPage() {
 
   return (
     <>
-      {loading && <GliftLoader />}
+      {showLoader && <GliftLoader />}
       <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
         <div className="w-full max-w-3xl px-4 sm:px-0">
           <h2 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-10">

--- a/src/app/admin/slider/page.tsx
+++ b/src/app/admin/slider/page.tsx
@@ -7,6 +7,7 @@ import ImageUploader from "@/app/admin/components/ImageUploader";
 import { AdminTextField } from "@/app/admin/components/AdminTextField";
 import CTAButton from "@/components/CTAButton";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 const sliderTypeOptions = [
   { value: "none", label: "Aucun slider" },
@@ -30,6 +31,7 @@ export default function AdminSliderPage() {
   const supabase = useMemo(() => createClient(), []);
 
   const [loading, setLoading] = useState(true);
+  const showLoader = useMinimumVisibility(loading);
   const [type, setType] = useState("none");
   const [count, setCount] = useState("1");
   const [slides, setSlides] = useState(
@@ -136,7 +138,7 @@ export default function AdminSliderPage() {
 
   return (
     <>
-      {loading && <GliftLoader />}
+      {showLoader && <GliftLoader />}
       <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
         <div className="w-full max-w-3xl">
           <h2 className="text-[30px] font-bold text-[#2E3271] text-center mb-10">

--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -14,6 +14,7 @@ import ErrorMessage from "@/components/ui/ErrorMessage";
 import ForgotPasswordModal from "@/components/auth/ForgotPasswordModal";
 import ModalMessage from "@/components/ui/ModalMessage";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 export default function ConnexionPage() {
   const [email, setEmail] = useState("");
@@ -31,6 +32,7 @@ export default function ConnexionPage() {
   const [loading, setLoading] = useState(false);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [showTransitionLoader, setShowTransitionLoader] = useState(false);
+  const showLoader = useMinimumVisibility(showTransitionLoader);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -143,7 +145,7 @@ export default function ConnexionPage() {
 
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
-      {showTransitionLoader ? <GliftLoader /> : null}
+      {showLoader ? <GliftLoader /> : null}
       <div className="w-full max-w-[564px] flex flex-col items-center">
         <h1 className="text-[26px] sm:text-[30px] font-bold text-[#2E3271] text-center mb-6">
           Connexion

--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -12,6 +12,7 @@ import type { PasswordFieldProps } from "@/components/forms/PasswordField";
 import Spinner from "@/components/ui/Spinner";
 import ModalMessage from "@/components/ui/ModalMessage";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 import ErrorMessage from "@/components/ui/ErrorMessage";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import { AuthApiError } from "@supabase/supabase-js";
@@ -273,16 +274,8 @@ export default function ResetPasswordPage() {
     }
   };
 
-  const loader =
-    stage === "verify"
-      ? (
-          <GliftLoader />
-        )
-      : stage === "done"
-        ? (
-            <GliftLoader />
-          )
-        : null;
+  const showLoader = useMinimumVisibility(stage === "verify" || stage === "done");
+  const loader = showLoader ? <GliftLoader /> : null;
 
   return (
     <>

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -8,6 +8,7 @@ import { useUser, UserProvider } from "@/context/UserContext";
 import SupabaseProvider from "@/components/SupabaseProvider";
 import AuthDebug from "@/components/AuthDebug";
 import GliftLoader from "@/components/ui/GliftLoader";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 interface ClientLayoutProps {
   children: React.ReactNode;
@@ -44,8 +45,9 @@ function ClientLayoutContent({
   isAdminPage,
 }: ClientLayoutContentProps) {
   const { isLoading } = useUser();
+  const showLoader = useMinimumVisibility(isLoading);
 
-  if (isLoading) {
+  if (showLoader) {
     return <GliftLoader />;
   }
 

--- a/src/components/shop/ShopGrid.tsx
+++ b/src/components/shop/ShopGrid.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import ShopCard from "@/components/shop/ShopCard";
 import GliftLoader from "@/components/ui/GliftLoader";
 import { createClient } from "@/lib/supabaseClient";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 type Offer = {
   id: number;
@@ -36,6 +37,7 @@ export default function ShopGrid({
 }) {
   const [offers, setOffers] = useState<Offer[]>([]);
   const [loading, setLoading] = useState(true);
+  const showLoader = useMinimumVisibility(loading);
 
   const getOrderForSortBy = (sortBy: string) => {
     switch (sortBy) {
@@ -143,9 +145,9 @@ export default function ShopGrid({
 
   return (
     <>
-      {loading && <GliftLoader />}
+      {showLoader && <GliftLoader />}
       <div className="relative mt-8">
-        {filteredOffers.length === 0 && !loading && (
+        {filteredOffers.length === 0 && !showLoader && !loading && (
           <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
         )}
 

--- a/src/components/store/StoreGrid.tsx
+++ b/src/components/store/StoreGrid.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import StoreCard from "@/components/store/StoreCard";
 import GliftLoader from "@/components/ui/GliftLoader";
 import { createClient } from "@/lib/supabaseClient";
+import useMinimumVisibility from "@/hooks/useMinimumVisibility";
 
 type Program = {
   id: number;
@@ -37,6 +38,7 @@ export default function StoreGrid({
   const [programs, setPrograms] = useState<Program[]>([]);
   const [loading, setLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const showLoader = useMinimumVisibility(loading);
 
   const getOrderForSortBy = (sortBy: string) => {
     switch (sortBy) {
@@ -117,9 +119,9 @@ export default function StoreGrid({
 
   return (
     <>
-      {loading && <GliftLoader />}
+      {showLoader && <GliftLoader />}
       <div className="relative mt-8">
-        {programs.length === 0 && !loading && (
+        {programs.length === 0 && !showLoader && !loading && (
           <p className="text-center text-[#5D6494]">Aucun programme trouvé.</p>
         )}
 

--- a/src/hooks/useMinimumVisibility.ts
+++ b/src/hooks/useMinimumVisibility.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Ensures that a visibility flag stays true for at least the provided duration.
+ * Useful for loaders to avoid flickering when the underlying loading state
+ * changes too quickly.
+ */
+export default function useMinimumVisibility(
+  isVisible: boolean,
+  minimumDuration = 1000
+) {
+  const [shouldBeVisible, setShouldBeVisible] = useState(isVisible);
+  const showStartTimeRef = useRef<number | null>(isVisible ? Date.now() : null);
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (isVisible) {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+      showStartTimeRef.current = Date.now();
+      setShouldBeVisible(true);
+      return;
+    }
+
+    const showStartTime = showStartTimeRef.current;
+    if (showStartTime === null) {
+      setShouldBeVisible(false);
+      return;
+    }
+
+    const elapsed = Date.now() - showStartTime;
+    if (elapsed >= minimumDuration) {
+      showStartTimeRef.current = null;
+      setShouldBeVisible(false);
+      return;
+    }
+
+    hideTimeoutRef.current = setTimeout(() => {
+      hideTimeoutRef.current = null;
+      showStartTimeRef.current = null;
+      setShouldBeVisible(false);
+    }, minimumDuration - elapsed);
+  }, [isVisible, minimumDuration]);
+
+  useEffect(() => {
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return shouldBeVisible;
+}


### PR DESCRIPTION
## Summary
- add a reusable `useMinimumVisibility` hook to guarantee loaders remain on-screen for at least one second
- apply the hook to layout, commerce grids, authentication flows, and admin pages that render the global loader

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3669cfd1c832eb9932f8f8ad45589