### PR TITLE
Keep account page mounted while showing loader overlay

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -47,12 +47,11 @@ function ClientLayoutContent({
   const { isLoading } = useUser();
   const showLoader = useMinimumVisibility(isLoading);
 
-  if (showLoader) {
-    return <GliftLoader />;
-  }
-
   return (
     <>
+      {showLoader ? (
+        <GliftLoader className="bg-white/80 backdrop-blur-sm" />
+      ) : null}
       {isAdminPage ? (
         <AdminHeader />
       ) : (

--- a/src/components/ui/GliftLoader.tsx
+++ b/src/components/ui/GliftLoader.tsx
@@ -1,9 +1,19 @@
 "use client";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
 
-export default function GliftLoader() {
+interface GliftLoaderProps {
+  className?: string;
+}
+
+export default function GliftLoader({ className }: GliftLoaderProps) {
   return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white px-4 text-center">
+    <div
+      className={cn(
+        "fixed inset-0 z-50 flex flex-col items-center justify-center bg-white px-4 text-center",
+        className,
+      )}
+    >
       <Image
         src="/logo-glift.svg"
         alt="Glift"


### PR DESCRIPTION
## Summary
- render the global loader as an overlay so account sections stay mounted while loading
- allow the Glift loader to accept custom styling and reuse it with a translucent background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3684d0e38832e90c83f6bf0eef095