### PR TITLE
Ensure account loader overlays content

### DIFF
--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -54,7 +54,7 @@ function ClientLayoutContent({
   return (
     <>
       {showLoader ? (
-        <GliftLoader className={isComptePage ? "bg-white/80 backdrop-blur-sm" : undefined} />
+        <GliftLoader className={isComptePage ? "bg-white" : undefined} />
       ) : null}
       {isAdminPage ? (
         <AdminHeader />

--- a/src/components/ui/GliftLoader.tsx
+++ b/src/components/ui/GliftLoader.tsx
@@ -10,7 +10,7 @@ export default function GliftLoader({ className }: GliftLoaderProps) {
   return (
     <div
       className={cn(
-        "fixed inset-0 z-50 flex flex-col items-center justify-center bg-white px-4 text-center",
+        "fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-white px-4 text-center",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- raise the GliftLoader overlay z-index so it sits above headers and page content
- ensure the /compte loader uses an opaque backdrop instead of a translucent blur

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e36af1d518832ebe25d10fdafdd841