### PR TITLE
Add account password update flow

### DIFF
--- a/src/app/api/account/change-password/route.ts
+++ b/src/app/api/account/change-password/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server"
+
+import { createClient } from "@/lib/supabase/server"
+import { getPasswordValidationState } from "@/utils/password"
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError) {
+      console.error("[change-password] failed to retrieve user", userError)
+      return NextResponse.json({ error: "user-fetch-failed" }, { status: 500 })
+    }
+
+    if (!user) {
+      return NextResponse.json({ error: "not-authenticated" }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "invalid-body" }, { status: 400 })
+    }
+
+    const currentPassword = typeof body.currentPassword === "string" ? body.currentPassword : ""
+    const newPassword = typeof body.newPassword === "string" ? body.newPassword : ""
+
+    if (!currentPassword || !newPassword) {
+      return NextResponse.json({ error: "missing-fields" }, { status: 400 })
+    }
+
+    if (currentPassword === newPassword) {
+      return NextResponse.json({ error: "same-password" }, { status: 400 })
+    }
+
+    const validation = getPasswordValidationState(newPassword)
+    if (!validation.isValid) {
+      return NextResponse.json({ error: "invalid-password-format" }, { status: 400 })
+    }
+
+    const email = user.email
+    if (!email) {
+      console.error("[change-password] user missing email")
+      return NextResponse.json({ error: "missing-email" }, { status: 400 })
+    }
+
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password: currentPassword,
+    })
+
+    if (signInError) {
+      if (signInError.status === 400 || signInError.status === 401) {
+        return NextResponse.json({ error: "invalid-current-password" }, { status: 400 })
+      }
+
+      console.error("[change-password] unable to verify current password", signInError)
+      return NextResponse.json({ error: "invalid-current-password" }, { status: 400 })
+    }
+
+    const { error: updateError } = await supabase.auth.updateUser({ password: newPassword })
+
+    if (updateError) {
+      console.error("[change-password] failed to update password", updateError)
+      return NextResponse.json({ error: "update-failed" }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("[change-password] unexpected error", error)
+    return NextResponse.json({ error: "unexpected-error" }, { status: 500 })
+  }
+}

--- a/src/components/account/sections/MotDePasseSection.tsx
+++ b/src/components/account/sections/MotDePasseSection.tsx
@@ -1,12 +1,247 @@
 "use client"
 
+import { FormEvent, useMemo, useState } from "react"
+import Image from "next/image"
+
 import AccountAccordionSection from "../AccountAccordionSection"
+import CTAButton from "@/components/CTAButton"
+import ForgotPasswordModal from "@/components/auth/ForgotPasswordModal"
+import {
+  PasswordField,
+  getPasswordValidationState,
+} from "@/components/forms/PasswordField"
+import { createClient } from "@/lib/supabaseClient"
+import ModalMessage from "@/components/ui/ModalMessage"
+
+const INVALID_CURRENT_PASSWORD_MESSAGE =
+  "L’ancien mot de passe que vous avez renseigné ne correspond pas au mot de passe actuellement utilisé pour vous connecter à votre compte."
+
+function PasswordCriteriaItem({ valid, text }: { valid: boolean; text: string }) {
+  const icon = valid ? "/icons/check-success.svg" : "/icons/check-neutral.svg"
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className={valid ? "text-[#00D591]" : "text-[#C2BFC6]"}>{text}</span>
+      <Image src={icon} alt="État" width={16} height={16} className="h-4 w-4" />
+    </div>
+  )
+}
+
+export const SECTION_ID = "mot-de-passe"
 
 export default function MotDePasseSection() {
+  const supabase = useMemo(() => createClient(), [])
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [currentPasswordError, setCurrentPasswordError] = useState<string | null>(null)
+  const [newPasswordError, setNewPasswordError] = useState<string | null>(null)
+  const [showForgotPassword, setShowForgotPassword] = useState(false)
+
+  const validation = useMemo(() => getPasswordValidationState(newPassword), [newPassword])
+  const isFormReady = currentPassword.trim() !== "" && validation.isValid
+  const canSubmit = isFormReady && !loading
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (loading || !canSubmit) {
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    setSuccess(false)
+    setCurrentPasswordError(null)
+    setNewPasswordError(null)
+
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      const accessToken = session?.access_token
+
+      const response = await fetch("/api/account/change-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({ currentPassword, newPassword }),
+      })
+
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | { success?: boolean }
+        | null
+
+      if (!response.ok) {
+        const errorCode = payload && "error" in payload ? payload.error : undefined
+
+        switch (errorCode) {
+          case "invalid-current-password":
+            setCurrentPasswordError(INVALID_CURRENT_PASSWORD_MESSAGE)
+            setError(INVALID_CURRENT_PASSWORD_MESSAGE)
+            break
+          case "same-password":
+            setNewPasswordError("Votre nouveau mot de passe doit être différent de l’actuel.")
+            setError("Votre nouveau mot de passe doit être différent de l’actuel.")
+            break
+          case "invalid-password-format":
+            setNewPasswordError("Votre nouveau mot de passe ne respecte pas les critères requis.")
+            setError("Impossible de mettre à jour le mot de passe.")
+            break
+          case "not-authenticated":
+            setError("Vous devez être connecté.")
+            break
+          case "missing-fields":
+          case "invalid-body":
+            setError("Informations manquantes pour modifier votre mot de passe.")
+            break
+          case "user-fetch-failed":
+          case "missing-email":
+          case "update-failed":
+          case "unexpected-error":
+            setError("Impossible de mettre à jour le mot de passe.")
+            break
+          default:
+            setError("Impossible de mettre à jour le mot de passe.")
+            break
+        }
+
+        return
+      }
+
+      setSuccess(true)
+      setCurrentPassword("")
+      setNewPassword("")
+    } catch (unknownError) {
+      console.error("[MotDePasseSection] unexpected error", unknownError)
+      setError("Une erreur est survenue. Merci de réessayer dans quelques instants.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
-    <AccountAccordionSection value="password" title="Mon mot de passe">
-      {/* Contenu à venir */}
-      <div></div>
+    <AccountAccordionSection value={SECTION_ID} title="Mon mot de passe">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center"
+      >
+        {error ? (
+          <div className="mb-6 flex w-full justify-center">
+            <ModalMessage
+              variant="warning"
+              title="Attention"
+              description={error}
+              className="w-full max-w-[564px]"
+            />
+          </div>
+        ) : null}
+
+        {success ? (
+          <div className="mb-6 flex w-full justify-center">
+            <ModalMessage
+              variant="success"
+              title="Félicitations !"
+              description="Votre mot de passe a été modifié avec succès. Vous devrez utiliser votre nouveau mot de passe sécurisé pour vous connecter la prochaine fois."
+              className="w-full max-w-[564px]"
+            />
+          </div>
+        ) : null}
+
+        <div className="flex w-full flex-col items-center">
+          <div className="mb-[10px] flex w-full justify-center">
+            <PasswordField
+              id="current-password"
+              name="current-password"
+              label="Ancien mot de passe"
+              placeholder="Votre mot de passe actuel"
+              value={currentPassword}
+              onChange={(nextValue) => {
+                setCurrentPassword(nextValue)
+                if (currentPasswordError) {
+                  setCurrentPasswordError(null)
+                }
+                if (error) {
+                  setError(null)
+                }
+                if (success) {
+                  setSuccess(false)
+                }
+              }}
+              externalError={currentPasswordError}
+              containerClassName="w-full max-w-[368px]"
+              messageContainerClassName="mt-[5px] min-h-[20px] text-left text-[13px] font-medium"
+              autoComplete="current-password"
+            />
+          </div>
+
+          <div className="flex w-full justify-center">
+            <PasswordField
+              id="new-password"
+              name="new-password"
+              label="Nouveau mot de passe"
+              value={newPassword}
+              onChange={(nextValue) => {
+                setNewPassword(nextValue)
+                if (newPasswordError) {
+                  setNewPasswordError(null)
+                }
+                if (error) {
+                  setError(null)
+                }
+                if (success) {
+                  setSuccess(false)
+                }
+              }}
+              validate={(value) => getPasswordValidationState(value).isValid}
+              criteriaRenderer={({ isFocused }) =>
+                isFocused ? (
+                  <div
+                    className="mt-3 space-y-2 rounded-[8px] bg-white px-4 py-3 text-[12px] text-[#5D6494]"
+                    style={{ boxShadow: "1px 1px 9px 1px rgba(0, 0, 0, 0.12)" }}
+                  >
+                    <PasswordCriteriaItem valid={validation.hasMinLength} text="Au moins 8 caractères" />
+                    <PasswordCriteriaItem valid={validation.hasLetter} text="Au moins 1 lettre" />
+                    <PasswordCriteriaItem valid={validation.hasNumber} text="Au moins 1 chiffre" />
+                    <PasswordCriteriaItem valid={validation.hasSymbol} text="Au moins 1 symbole" />
+                  </div>
+                ) : null
+              }
+              blurDelay={100}
+              externalError={newPasswordError}
+              containerClassName="w-full max-w-[368px]"
+              messageContainerClassName="mt-[5px] min-h-[20px] text-left text-[13px] font-medium"
+              autoComplete="new-password"
+            />
+          </div>
+        </div>
+
+        <CTAButton
+          type="submit"
+          className="mt-6 w-full max-w-[260px] font-bold"
+          disabled={!isFormReady || loading}
+          loading={loading}
+          loadingText="En cours..."
+          variant={isFormReady ? "active" : "inactive"}
+        >
+          Modifier mon mot de passe
+        </CTAButton>
+
+        <button
+          type="button"
+          onClick={() => setShowForgotPassword(true)}
+          className="mt-4 text-[14px] font-semibold text-[#7069FA] transition-colors hover:text-[#6660E4]"
+        >
+          Mot de passe oublié ?
+        </button>
+      </form>
+
+      <ForgotPasswordModal open={showForgotPassword} onClose={() => setShowForgotPassword(false)} />
     </AccountAccordionSection>
   )
 }

--- a/src/components/forms/PasswordField.tsx
+++ b/src/components/forms/PasswordField.tsx
@@ -4,18 +4,7 @@ import * as React from "react";
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
-
-export const PASSWORD_MIN_LENGTH = 8;
-
-export const getPasswordValidationState = (value: string) => {
-  const hasMinLength = value.length >= PASSWORD_MIN_LENGTH;
-  const hasLetter = /[a-zA-Z]/.test(value);
-  const hasNumber = /\d/.test(value);
-  const hasSymbol = /[!@#$%^&*(),.?":{}|<>]/.test(value);
-  const isValid = hasMinLength && hasLetter && hasNumber && hasSymbol;
-
-  return { hasMinLength, hasLetter, hasNumber, hasSymbol, isValid } as const;
-};
+export { PASSWORD_MIN_LENGTH, getPasswordValidationState } from "@/utils/password";
 
 export interface PasswordFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange" | "type"> {

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,11 @@
+export const PASSWORD_MIN_LENGTH = 8
+
+export const getPasswordValidationState = (value: string) => {
+  const hasMinLength = value.length >= PASSWORD_MIN_LENGTH
+  const hasLetter = /[a-zA-Z]/.test(value)
+  const hasNumber = /\d/.test(value)
+  const hasSymbol = /[!@#$%^&*(),.?":{}|<>]/.test(value)
+  const isValid = hasMinLength && hasLetter && hasNumber && hasSymbol
+
+  return { hasMinLength, hasLetter, hasNumber, hasSymbol, isValid } as const
+}


### PR DESCRIPTION
## Summary
- add the Mon mot de passe accordion content with validation, messaging, and forgot-password modal trigger
- create an API route backed by Supabase to validate and update the password
- centralize password validation helpers for reuse across client and server

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e404193ab8832ebb51dc9ecdc446d5