### PR TITLE
Adjust same-password error handling and CTA loading styling

### DIFF
--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -135,17 +135,19 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
       ]
     );
 
+    const isDisabledOrLoading = disabled || effectiveLoading;
+    const resolvedVariant = isDisabledOrLoading ? "inactive" : variant;
+
     const baseClasses = clsx(
       "inline-flex items-center justify-center gap-2 h-[44px] px-[15px] rounded-full font-semibold text-[16px] whitespace-nowrap",
       "transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-      variant === "active" &&
+      resolvedVariant === "active" &&
         "bg-[#7069FA] text-white hover:bg-[#6660E4] focus-visible:ring-[#7069FA]",
-      variant === "inactive" &&
+      resolvedVariant === "inactive" &&
         "bg-[#F2F1F6] text-[#D7D4DC] hover:bg-[#ECE9F1] focus-visible:ring-[#D7D4DC]",
-      variant === "danger" &&
+      resolvedVariant === "danger" &&
         "bg-[#EF4F4E] text-white hover:bg-[#BA2524] focus-visible:ring-[#EF4F4E]",
-      (disabled || effectiveLoading) &&
-        "cursor-not-allowed opacity-100",
+      isDisabledOrLoading && "cursor-not-allowed opacity-100",
       className
     );
 
@@ -173,8 +175,8 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
           ref={elementRef as React.MutableRefObject<HTMLAnchorElement>}
           onClick={handleClick as unknown as (event: MouseEvent<HTMLAnchorElement>) => void}
           className={baseClasses}
-          aria-disabled={disabled || effectiveLoading}
-          tabIndex={disabled || effectiveLoading ? -1 : rest.tabIndex}
+          aria-disabled={isDisabledOrLoading}
+          tabIndex={isDisabledOrLoading ? -1 : rest.tabIndex}
           target={target}
           rel={rel}
           style={computedStyle}
@@ -189,7 +191,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
         {...rest}
         ref={elementRef as React.MutableRefObject<HTMLButtonElement>}
         type={type as ButtonHTMLAttributes<HTMLButtonElement>["type"]}
-        disabled={disabled || effectiveLoading}
+        disabled={isDisabledOrLoading}
         onClick={handleClick as unknown as (event: MouseEvent<HTMLButtonElement>) => void}
         className={baseClasses}
         style={computedStyle}

--- a/src/components/account/sections/MotDePasseSection.tsx
+++ b/src/components/account/sections/MotDePasseSection.tsx
@@ -50,6 +50,8 @@ export default function MotDePasseSection() {
       return
     }
 
+    const hadPreviousSuccess = success
+
     setLoading(true)
     setError(null)
     setSuccess(false)
@@ -86,8 +88,10 @@ export default function MotDePasseSection() {
             setError(INVALID_CURRENT_PASSWORD_MESSAGE)
             break
           case "same-password":
-            setNewPasswordError("Votre nouveau mot de passe doit être différent de l’actuel.")
             setError("Votre nouveau mot de passe doit être différent de l’actuel.")
+            if (hadPreviousSuccess) {
+              setSuccess(true)
+            }
             break
           case "invalid-password-format":
             setNewPasswordError("Votre nouveau mot de passe ne respecte pas les critères requis.")


### PR DESCRIPTION
## Summary
- keep the password change success banner when a same-password error occurs without flagging the input field
- ensure CTA buttons render with the inactive styling whenever they are disabled or loading so the loading state is greyed out

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b77259cc832ea331573a9376fb1f