### PR TITLE
Keep password fields neutral on specific errors

### DIFF
--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -155,7 +155,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
       <span className="inline-flex items-center gap-2">
         <span
           aria-hidden
-          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
         />
         <span>{loadingText}</span>
       </span>

--- a/src/components/account/sections/MotDePasseSection.tsx
+++ b/src/components/account/sections/MotDePasseSection.tsx
@@ -10,6 +10,7 @@ import {
   PasswordField,
   getPasswordValidationState,
 } from "@/components/forms/PasswordField"
+import type { PasswordFieldProps } from "@/components/forms/PasswordField"
 import { createClient } from "@/lib/supabaseClient"
 import ModalMessage from "@/components/ui/ModalMessage"
 
@@ -38,6 +39,9 @@ export default function MotDePasseSection() {
   const [success, setSuccess] = useState(false)
   const [currentPasswordError, setCurrentPasswordError] = useState<string | null>(null)
   const [newPasswordError, setNewPasswordError] = useState<string | null>(null)
+  const [newPasswordStatusOverride, setNewPasswordStatusOverride] = useState<
+    PasswordFieldProps["statusOverride"]
+  >()
   const [showForgotPassword, setShowForgotPassword] = useState(false)
 
   const validation = useMemo(() => getPasswordValidationState(newPassword), [newPassword])
@@ -57,6 +61,7 @@ export default function MotDePasseSection() {
     setSuccess(false)
     setCurrentPasswordError(null)
     setNewPasswordError(null)
+    setNewPasswordStatusOverride(undefined)
 
     try {
       const {
@@ -84,17 +89,18 @@ export default function MotDePasseSection() {
 
         switch (errorCode) {
           case "invalid-current-password":
-            setCurrentPasswordError(INVALID_CURRENT_PASSWORD_MESSAGE)
             setError(INVALID_CURRENT_PASSWORD_MESSAGE)
             break
           case "same-password":
             setError("Votre nouveau mot de passe doit être différent de l’actuel.")
+            setNewPasswordStatusOverride("neutral")
             if (hadPreviousSuccess) {
               setSuccess(true)
             }
             break
           case "invalid-password-format":
             setNewPasswordError("Votre nouveau mot de passe ne respecte pas les critères requis.")
+            setNewPasswordStatusOverride(undefined)
             setError("Impossible de mettre à jour le mot de passe.")
             break
           case "not-authenticated":
@@ -121,6 +127,7 @@ export default function MotDePasseSection() {
       setSuccess(true)
       setCurrentPassword("")
       setNewPassword("")
+      setNewPasswordStatusOverride(undefined)
     } catch (unknownError) {
       console.error("[MotDePasseSection] unexpected error", unknownError)
       setError("Une erreur est survenue. Merci de réessayer dans quelques instants.")
@@ -195,6 +202,9 @@ export default function MotDePasseSection() {
                 if (newPasswordError) {
                   setNewPasswordError(null)
                 }
+                if (newPasswordStatusOverride) {
+                  setNewPasswordStatusOverride(undefined)
+                }
                 if (error) {
                   setError(null)
                 }
@@ -218,6 +228,7 @@ export default function MotDePasseSection() {
               }
               blurDelay={100}
               externalError={newPasswordError}
+              statusOverride={newPasswordStatusOverride}
               containerClassName="w-full max-w-[368px]"
               messageContainerClassName="mt-[5px] min-h-[20px] text-left text-[13px] font-medium"
               autoComplete="new-password"

--- a/src/components/forms/PasswordField.tsx
+++ b/src/components/forms/PasswordField.tsx
@@ -23,6 +23,7 @@ export interface PasswordFieldProps
   criteriaRenderer?: (context: { isFocused: boolean; isValid: boolean; value: string }) => React.ReactNode;
   blurDelay?: number;
   defaultShowPassword?: boolean;
+  statusOverride?: "neutral" | "success" | "error";
 }
 
 export function PasswordField({
@@ -44,6 +45,7 @@ export function PasswordField({
   criteriaRenderer,
   blurDelay = 0,
   defaultShowPassword = false,
+  statusOverride,
   onBlur,
   onFocus,
   ...rest
@@ -63,18 +65,38 @@ export function PasswordField({
   const hasValue = value.trim() !== "";
   const canValidate = typeof validate === "function";
   const isValid = validationResult.isValid;
-  const showSuccess = canValidate && touched && !focused && isValid && !externalError;
+  const showSuccessBase = canValidate && touched && !focused && isValid && !externalError;
   const showInternalError = canValidate && touched && !focused && hasValue && !isValid;
   const showExternalError = Boolean(externalError) && !focused;
-  const showError = showInternalError || showExternalError;
+  const showErrorBase = showInternalError || showExternalError;
 
-  const message = showExternalError
-    ? externalError
-    : showSuccess
-    ? successMessage
-    : showInternalError
-    ? errorMessage
-    : null;
+  let showSuccess = showSuccessBase;
+  let showError = showErrorBase;
+  let message: string | null = null;
+
+  if (statusOverride === "neutral") {
+    showSuccess = false;
+    showError = false;
+    message = null;
+  } else if (statusOverride === "success") {
+    showSuccess = true;
+    showError = false;
+    message = successMessage;
+  } else if (statusOverride === "error") {
+    showSuccess = false;
+    showError = true;
+    message = externalError ?? errorMessage;
+  } else {
+    if (showExternalError) {
+      message = externalError ?? null;
+    } else if (showSuccess) {
+      message = successMessage;
+    } else if (showInternalError) {
+      message = errorMessage;
+    } else {
+      message = null;
+    }
+  }
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     setFocused(true);


### PR DESCRIPTION
## Summary
- keep the current and new password fields neutral when appropriate by clearing inline errors and driving a status override
- allow `PasswordField` consumers to force a neutral, success, or error state via a new `statusOverride` prop
- make the CTA button loading spinner inherit the current text color so it renders grey while disabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b958338c832eb477306d67b37bc7