### PR TITLE
Ensure loading buttons reuse CTAButton component

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -5,11 +5,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import CTAButton from "@/components/CTAButton";
 import { EmailField, isValidEmail } from "@/components/forms/EmailField";
 import { PasswordField } from "@/components/forms/PasswordField";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import { IconCheckbox } from "@/components/ui/IconCheckbox";
-import Spinner from "@/components/ui/Spinner";
 import ErrorMessage from "@/components/ui/ErrorMessage";
 import ForgotPasswordModal from "@/components/auth/ForgotPasswordModal";
 import ModalMessage from "@/components/ui/ModalMessage";
@@ -137,12 +137,6 @@ export default function ConnexionPage() {
     }
   };
 
-  const buttonStateClasses = loading
-    ? "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
-    : isFormValid
-    ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
-    : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed";
-
   return (
     <main className="min-h-screen bg-[#FBFCFE] flex justify-center px-4 pt-[140px] pb-[40px]">
       {showLoader ? <GliftLoader /> : null}
@@ -229,31 +223,26 @@ export default function ConnexionPage() {
 
           {/* Bouton Se connecter */}
           <div className="w-full flex justify-center">
-            <button
+            <CTAButton
               type="submit"
-              disabled={!isFormValid || loading}
-              className={`w-full max-w-[160px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2 ${buttonStateClasses}`}
+              className="w-full max-w-[160px] font-bold"
+              disabled={!isFormValid}
+              loading={loading}
+              loadingText="En cours..."
             >
-              {loading ? (
-                <span className="inline-flex items-center gap-2 text-[15px]">
-                  <Spinner size="md" ariaLabel="Connexion en cours" />
-                  En cours
-                </span>
-              ) : (
-                <>
-                  <Image
-                    src="/icons/cadena_defaut.svg"
-                    alt="Icône cadenas"
-                    width={20}
-                    height={20}
-                    className={`transition-colors ${
-                      isFormValid ? "invert brightness-0" : ""
-                    }`}
-                  />
-                  Se connecter
-                </>
-              )}
-            </button>
+              <>
+                <Image
+                  src="/icons/cadena_defaut.svg"
+                  alt="Icône cadenas"
+                  width={20}
+                  height={20}
+                  className={`transition-colors ${
+                    isFormValid && !loading ? "invert brightness-0" : ""
+                  }`}
+                />
+                Se connecter
+              </>
+            </CTAButton>
           </div>
 
           {/* Lien inscription */}

--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import CTAButton from "@/components/CTAButton";
 import StepDots from "@/components/onboarding/StepDots";
-import Spinner from "@/components/ui/Spinner";
 import DropdownField from "@/components/account/fields/DropdownField";
 import ToggleField from "@/components/account/fields/ToggleField";
 import BirthDateField from "@/components/account/fields/BirthDateField";
@@ -339,28 +339,15 @@ const InformationsPage = () => {
         </FieldRow>
 
         <div className="mt-5 flex flex-col items-center">
-          <button
+          <CTAButton
             type="submit"
-            aria-busy={hookLoading || submitting}
-            aria-disabled={hookLoading || submitting}
+            className="px-[30px] font-bold"
             disabled={!isFormValid && !(hookLoading || submitting)}
-            className={`inline-flex h-[44px] items-center justify-center rounded-[25px] px-[15px] text-[16px] font-bold ${
-              hookLoading || submitting
-                ? "bg-[#7069FA] text-white opacity-100 cursor-wait pointer-events-none"
-                : !isFormValid
-                ? "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
-                : "bg-[#7069FA] text-white hover:bg-[#6660E4]"
-            }`}
+            loading={hookLoading || submitting}
+            loadingText="En cours..."
           >
-            {hookLoading || submitting ? (
-              <span className="inline-flex items-center gap-2">
-                <Spinner size="md" ariaLabel="En cours" />
-                En cours...
-              </span>
-            ) : (
-              "Enregistrer mes informations"
-            )}
-          </button>
+            Enregistrer mes informations
+          </CTAButton>
 
           <button
             type="button"

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import CTAButton from "@/components/CTAButton";
 import { EmailField, isValidEmail } from "@/components/forms/EmailField";
 import { PasswordField, getPasswordValidationState } from "@/components/forms/PasswordField";
 import { IconCheckbox } from "@/components/ui/IconCheckbox";
@@ -245,24 +246,26 @@ const AccountCreationPage = () => {
           {error && <p className="text-[#EF4444] mb-4 text-sm text-center max-w-[368px]">{error}</p>}
 
           <div className="w-full flex justify-center mt-[10px]">
-            <button
+            <CTAButton
               type="submit"
+              className="w-full max-w-[220px] font-bold"
               disabled={!isFormValid}
-              className={`w-full max-w-[220px] h-[44px] rounded-[25px] text-[16px] font-bold text-center transition flex items-center justify-center gap-2 ${
-                isFormValid
-                  ? "bg-[#7069FA] text-white hover:bg-[#6660E4] cursor-pointer"
-                  : "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
-              }`}
+              loading={loading}
+              loadingText="En cours..."
             >
-              <Image
-                src="/icons/cadena_defaut.svg"
-                alt="Icône cadenas"
-                width={20}
-                height={20}
-                className={`w-[20px] h-[20px] transition-colors ${isFormValid ? "invert brightness-0" : ""}`}
-              />
-              {loading ? "En cours..." : "Créer mon compte"}
-            </button>
+              <>
+                <Image
+                  src="/icons/cadena_defaut.svg"
+                  alt="Icône cadenas"
+                  width={20}
+                  height={20}
+                  className={`h-[20px] w-[20px] transition-colors ${
+                    isFormValid ? "invert brightness-0" : ""
+                  }`}
+                />
+                Créer mon compte
+              </>
+            </CTAButton>
           </div>
 
           <p className="mt-[20px] text-sm font-semibold text-[#5D6494] text-center self-center">

--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -4,12 +4,12 @@ import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import CTAButton from "@/components/CTAButton";
 import {
   PasswordField,
   getPasswordValidationState,
 } from "@/components/forms/PasswordField";
 import type { PasswordFieldProps } from "@/components/forms/PasswordField";
-import Spinner from "@/components/ui/Spinner";
 import ModalMessage from "@/components/ui/ModalMessage";
 import GliftLoader from "@/components/ui/GliftLoader";
 import useMinimumVisibility from "@/hooks/useMinimumVisibility";
@@ -386,25 +386,15 @@ export default function ResetPasswordPage() {
 
                 {/* CTA */}
                 <div className="w-full flex justify-center mt-[5px]">
-                  <button
+                  <CTAButton
                     type="submit"
-                    disabled={!isFormValid || submitting}
-                    aria-busy={submitting}
-                    className={`inline-flex h-[44px] items-center justify-center rounded-[25px] px-[15px] text-[16px] font-bold ${
-                      !isFormValid || submitting
-                        ? "bg-[#F2F1F6] text-[#D7D4DC] cursor-not-allowed"
-                        : "bg-[#7069FA] text-white hover:bg-[#6660E4]"
-                    }`}
+                    className="font-bold"
+                    disabled={!isFormValid}
+                    loading={submitting}
+                    loadingText="En cours..."
                   >
-                    {submitting ? (
-                      <span className="inline-flex items-center gap-2">
-                        <Spinner size="md" ariaLabel="En cours" />
-                        En cours...
-                      </span>
-                    ) : (
-                      "Enregistrer"
-                    )}
-                  </button>
+                    Enregistrer
+                  </CTAButton>
                 </div>
               </form>
             </>

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -16,6 +16,8 @@ import {
   useState,
 } from "react";
 
+import Spinner from "@/components/ui/Spinner";
+
 type CTAElement = HTMLButtonElement | HTMLAnchorElement;
 
 type BaseProps = {
@@ -153,9 +155,9 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
 
     const content = effectiveLoading ? (
       <span className="inline-flex items-center gap-2">
-        <span
-          aria-hidden
-          className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+        <Spinner
+          size="sm"
+          ariaLabel={typeof loadingText === "string" ? loadingText : undefined}
         />
         <span>{loadingText}</span>
       </span>
@@ -176,6 +178,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
           onClick={handleClick as unknown as (event: MouseEvent<HTMLAnchorElement>) => void}
           className={baseClasses}
           aria-disabled={isDisabledOrLoading}
+          aria-busy={effectiveLoading || undefined}
           tabIndex={isDisabledOrLoading ? -1 : rest.tabIndex}
           target={target}
           rel={rel}
@@ -194,6 +197,7 @@ const CTAButton = forwardRef<CTAElement, CTAButtonProps>(
         disabled={isDisabledOrLoading}
         onClick={handleClick as unknown as (event: MouseEvent<HTMLButtonElement>) => void}
         className={baseClasses}
+        aria-busy={effectiveLoading || undefined}
         style={computedStyle}
       >
         {content}


### PR DESCRIPTION
## Summary
- update CTAButton to render the shared spinner and expose aria-busy when loading
- replace custom loading button markup in auth flows with CTAButton for consistent disabled/loading UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4bbe876a4832e8be75ae0be94d811