### PR TITLE
Fix Header outside click listener typing

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { MouseEvent, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useUser } from "@/context/UserContext";
 import { createClientComponentClient } from "@/lib/supabase/client";
 import CTAButton from "@/components/CTAButton";
@@ -33,7 +34,7 @@ export default function Header({ disconnected = false }: HeaderProps) {
   const showAuthenticatedUI = isAuthenticated && !isRecoverySession && !disconnected;
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutside = (event: globalThis.MouseEvent) => {
       if (
         dropdownRef.current &&
         !dropdownRef.current.contains(event.target as Node)
@@ -54,7 +55,7 @@ export default function Header({ disconnected = false }: HeaderProps) {
   }, []);
 
   const handleAccountLinkClick = (
-    event: MouseEvent<HTMLAnchorElement>,
+    event: ReactMouseEvent<HTMLAnchorElement>,
     sectionHash: string,
   ) => {
     if (pathname === "/compte") {


### PR DESCRIPTION
## Summary
- update the Header dropdown outside click handler to rely on the DOM MouseEvent type
- use ReactMouseEvent for account link clicks to maintain proper React typings

## Testing
- npx tsc --noEmit
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4bdb21b3c832e9941371a766555bc