### PR TITLE
Redirect onboarding profile completion to account page

### DIFF
--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -191,8 +191,8 @@ const InformationsPage = () => {
       console.log(`[onboarding] submit() resolved, success = ${ok}`);
 
       if (ok) {
-        console.log("[onboarding] navigation vers /entrainements");
-        router.push("/entrainements");
+        console.log("[onboarding] navigation vers /compte#mes-informations");
+        router.push("/compte#mes-informations");
       }
     } catch (err) {
       console.error("[onboarding] submit() erreur inattendue:", err);
@@ -352,8 +352,10 @@ const InformationsPage = () => {
           <button
             type="button"
             onClick={() => {
-              console.log("[onboarding] clic 'Ignorer pour le moment' → /entrainements");
-              router.push("/entrainements");
+              console.log(
+                "[onboarding] clic 'Ignorer pour le moment' → /compte#mes-informations"
+              );
+              router.push("/compte#mes-informations");
             }}
             className="mt-5 text-[14px] font-semibold text-[#7069FA] hover:text-[#6660E4]"
           >


### PR DESCRIPTION
## Summary
- Redirect the onboarding profile completion flow to the account information section after saving or skipping additional details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f9d51ae4832ea37ce0ff8c35a358