### PR TITLE
Align trial period and button font weight

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -225,7 +225,7 @@ export default function ConnexionPage() {
           <div className="w-full flex justify-center">
             <CTAButton
               type="submit"
-              className="w-full max-w-[160px] font-bold"
+              className="w-full max-w-[160px] font-semibold"
               disabled={!isFormValid}
               loading={loading}
               loadingText="En cours..."

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  button,
+  [type="button"],
+  [type="submit"],
+  [type="reset"] {
+    @apply font-semibold;
+  }
+}
+
 html, body {
   @apply bg-[#FBFCFE] text-[#202121] font-sans antialiased;
 }

--- a/src/app/inscription/informations/page.tsx
+++ b/src/app/inscription/informations/page.tsx
@@ -341,7 +341,7 @@ const InformationsPage = () => {
         <div className="mt-5 flex flex-col items-center">
           <CTAButton
             type="submit"
-            className="px-[30px] font-bold"
+            className="px-[30px] font-semibold"
             disabled={!isFormValid && !(hookLoading || submitting)}
             loading={hookLoading || submitting}
             loadingText="En cours..."

--- a/src/app/inscription/page.tsx
+++ b/src/app/inscription/page.tsx
@@ -248,7 +248,7 @@ const AccountCreationPage = () => {
           <div className="w-full flex justify-center mt-[10px]">
             <CTAButton
               type="submit"
-              className="w-full max-w-[220px] font-bold"
+              className="w-full max-w-[220px] font-semibold"
               disabled={!isFormValid}
               loading={loading}
               loadingText="En cours..."

--- a/src/app/inscription/paiement/page.tsx
+++ b/src/app/inscription/paiement/page.tsx
@@ -34,7 +34,7 @@ const PaymentPage = () => {
     if (explicit) return explicit;
 
     const now = new Date();
-    now.setDate(now.getDate() + 14);
+    now.setDate(now.getDate() + 30);
     return formatFr(now);
   }, [trialEndParam]);
 
@@ -142,7 +142,7 @@ const PaymentPage = () => {
             onClick={handleContinue}
             disabled={btnDisabled}
             aria-disabled={btnDisabled}
-            className={`inline-flex items-center justify-center h-[48px] rounded-[25px] px-[15px] text-[16px] font-bold ${
+            className={`inline-flex items-center justify-center h-[48px] rounded-[25px] px-[15px] text-[16px] font-semibold ${
               btnDisabled
                 ? "bg-[#ECE9F1] text-[#D7D4DC] cursor-not-allowed"
                 : "bg-[#7069FA] text-white hover:bg-[#6660E4]"

--- a/src/app/reinitialiser-mot-de-passe/page.tsx
+++ b/src/app/reinitialiser-mot-de-passe/page.tsx
@@ -388,7 +388,7 @@ export default function ResetPasswordPage() {
                 <div className="w-full flex justify-center mt-[5px]">
                   <CTAButton
                     type="submit"
-                    className="font-bold"
+                    className="font-semibold"
                     disabled={!isFormValid}
                     loading={submitting}
                     loadingText="En cours..."

--- a/src/components/FooterPublic.tsx
+++ b/src/components/FooterPublic.tsx
@@ -24,7 +24,7 @@ export default function Footer() {
 
         {/* Right - CTA */}
         <div className="flex flex-col items-start gap-2">
-        <CTAButton href="/inscription?plan=premium" className="font-bold text-[16px]">
+        <CTAButton href="/inscription?plan=premium" className="font-semibold text-[16px]">
           <span className="inline-flex items-center gap-2">
             Tester gratuitement
             <Image src="/icons/arrow.svg" className="ml-[-5px]" alt="Flèche" width={25} height={25} />

--- a/src/components/account/AccordionTrigger.tsx
+++ b/src/components/account/AccordionTrigger.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react'
 export default function AccordionTrigger({ children }: { children: ReactNode }) {
   return (
     <BaseTrigger
-      className="h-[60px] font-bold text-[#5D6494] hover:text-[#3A416F] text-[16px] pl-4 pr-6 py-3 hover:no-underline flex items-center justify-between group appearance-none before:hidden after:hidden w-full data-[state=open]:rounded-t-[5px] rounded-[5px]"
+      className="h-[60px] font-semibold text-[#5D6494] hover:text-[#3A416F] text-[16px] pl-4 pr-6 py-3 hover:no-underline flex items-center justify-between group appearance-none before:hidden after:hidden w-full data-[state=open]:rounded-t-[5px] rounded-[5px]"
     >
       <span>{children}</span>
       <span className="relative w-[14px] h-[8px] mt-[2px] shrink-0 transition-transform duration-200 group-data-[state=open]:rotate-180">

--- a/src/components/account/fields/SubmitButton.tsx
+++ b/src/components/account/fields/SubmitButton.tsx
@@ -25,7 +25,7 @@ export default function SubmitButton({
         disabled={isDisabled}
         loading={loading}
         variant={isDisabled ? "inactive" : "active"}
-        className="font-bold"
+        className="font-semibold"
       >
         {label}
       </CTAButton>

--- a/src/components/account/sections/MotDePasseSection.tsx
+++ b/src/components/account/sections/MotDePasseSection.tsx
@@ -238,7 +238,7 @@ export default function MotDePasseSection() {
 
         <CTAButton
           type="submit"
-          className="mt-4 w-full max-w-[260px] font-bold"
+          className="mt-4 w-full max-w-[260px] font-semibold"
           disabled={!isFormReady || loading}
           loading={loading}
           loadingText="En cours..."

--- a/src/components/shop/ShopCard.tsx
+++ b/src/components/shop/ShopCard.tsx
@@ -303,7 +303,7 @@ export default function ShopCard({ offer }: Props) {
               onMouseEnter={() => setLockedHover(true)}
               onMouseLeave={() => setLockedHover(false)}
               variant="inactive"
-              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
+              className="mt-[20px] mb-[30px] mx-auto font-semibold text-[16px]"
             >
               <span className="inline-flex items-center gap-2">
                 <Image
@@ -321,7 +321,7 @@ export default function ShopCard({ offer }: Props) {
               onMouseEnter={() => setLockedHover(true)}
               onMouseLeave={() => setLockedHover(false)}
               variant="inactive"
-              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
+              className="mt-[20px] mb-[30px] mx-auto font-semibold text-[16px]"
             >
               <span className="inline-flex items-center gap-2">
                 <Image
@@ -337,7 +337,7 @@ export default function ShopCard({ offer }: Props) {
             // Authentifié + premium → bouton actif
             <CTAButton
               onClick={handleClick}
-              className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
+              className="mt-[20px] mb-[30px] mx-auto font-semibold text-[16px]"
             >
               Profiter de cette offre
             </CTAButton>
@@ -346,7 +346,7 @@ export default function ShopCard({ offer }: Props) {
           // Offres non premium → toujours accessibles
           <CTAButton
             onClick={handleClick}
-            className="mt-[20px] mb-[30px] mx-auto font-bold text-[16px]"
+            className="mt-[20px] mb-[30px] mx-auto font-semibold text-[16px]"
           >
             Profiter de cette offre
           </CTAButton>

--- a/src/components/shop/ShopPagination.tsx
+++ b/src/components/shop/ShopPagination.tsx
@@ -80,7 +80,7 @@ export default function ShopPagination({ currentPage, totalPrograms, onPageChang
             className={`text-[14px] px-2 transition
               ${
                 page === currentPage
-                  ? "text-[#3A416F] font-bold"
+                  ? "text-[#3A416F] font-semibold"
                   : "text-[#5D6494] font-semibold"
               }`}
           >

--- a/src/components/store/StoreCard.tsx
+++ b/src/components/store/StoreCard.tsx
@@ -117,7 +117,7 @@ export default function StoreCard({ program, isAuthenticated }: Props) {
           <CTAButton
             onClick={handleDownload}
             loading={loading}
-            className="mx-auto font-bold text-[16px]"
+            className="mx-auto text-[16px] font-semibold"
           >
             <span className="inline-flex items-center gap-2">
               Télécharger
@@ -130,7 +130,7 @@ export default function StoreCard({ program, isAuthenticated }: Props) {
             onMouseEnter={() => setLockedHover(true)}
             onMouseLeave={() => setLockedHover(false)}
             variant="inactive"
-            className="mx-auto font-bold text-[16px]"
+            className="mx-auto text-[16px] font-semibold"
           >
             <span className="inline-flex items-center gap-2">
               <Image

--- a/src/components/store/StorePagination.tsx
+++ b/src/components/store/StorePagination.tsx
@@ -80,7 +80,7 @@ export default function StorePagination({ currentPage, totalPrograms, onPageChan
             className={`text-[14px] px-2 transition
               ${
                 page === currentPage
-                  ? "text-[#3A416F] font-bold"
+                  ? "text-[#3A416F] font-semibold"
                   : "text-[#5D6494] font-semibold"
               }`}
           >


### PR DESCRIPTION
## Summary
- set the default signup trial deadline to 30 days in the payment step
- standardize button typography to font-semibold via global base styles and CTA updates across forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4fcd66554832eb1468ded360c8835