### PR TITLE
Add info tooltips to tarifs page

### DIFF
--- a/public/icons/info_blue.svg
+++ b/public/icons/info_blue.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="9" cy="9" r="9" fill="#E9EDFF" />
+  <rect x="8.25" y="7" width="1.5" height="6" rx="0.75" fill="#2E3271" />
+  <circle cx="9" cy="5" r="1" fill="#2E3271" />
+</svg>

--- a/public/icons/info_blue_hover.svg
+++ b/public/icons/info_blue_hover.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="9" cy="9" r="9" fill="#2E3271" />
+  <rect x="8.25" y="7" width="1.5" height="6" rx="0.75" fill="white" />
+  <circle cx="9" cy="5" r="1" fill="white" />
+</svg>

--- a/src/app/tarifs/page.tsx
+++ b/src/app/tarifs/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import CTAButton from "@/components/CTAButton";
+import InfoAdornment from "@/components/InfoAdornment";
 
 export default function TarifsPage() {
   return (
@@ -84,8 +85,36 @@ export default function TarifsPage() {
     <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} /><b className="text-[#3A416F]">Un nombre illimité</b> d&apos;entraînements</li>
     <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} /><b className="text-[#3A416F]">Un nombre illimité</b> d&apos;exercices</li>
     <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} />Un tableau de bord personnalisé</li>
-    <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} /><b className="text-[#3A416F]">Accès aux programmes du <span className="relative inline-block"><Link href="/store" className="underline decoration-dotted hover:decoration-solid underline-offset-4 peer">Glift Store</Link><span className="absolute left-full top-1/2 -translate-y-1/2 ml-3 w-[230px] px-3 py-2 text-white text-[14px] font-medium bg-[#2E3142] rounded-md shadow-lg opacity-0 peer-hover:opacity-100 transition-opacity z-10 pointer-events-none">Des programmes gratuits à télécharger et à utiliser directement dans Glift.<span className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-3 h-3 rotate-45 bg-[#2E3142]"></span></span></span></b></li>
-    <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} /><b className="text-[#3A416F]">Accès aux offres Premium de la <span className="relative inline-block"><Link href="/shop" className="underline decoration-dotted hover:decoration-solid underline-offset-4 peer">Glift Shop</Link><span className="absolute left-full top-1/2 -translate-y-1/2 ml-3 w-[230px] px-3 py-2 text-white text-[14px] font-medium bg-[#2E3142] rounded-md shadow-lg opacity-0 peer-hover:opacity-100 transition-opacity z-10 pointer-events-none">Une sélection d’offres régulièrement mise à jour correspondant à votre profil.<span className="absolute left-[-6px] top-1/2 -translate-y-1/2 w-3 h-3 rotate-45 bg-[#2E3142]"></span></span></span></b></li>
+    <li className="flex items-center gap-1">
+      <Image src="/icons/inclus.svg" alt="Check" width={30} height={30} />
+      <span className="inline-flex items-center gap-1">
+        <span className="font-bold text-[#3A416F]">Accès aux programmes du Glift Store</span>
+        <InfoAdornment
+          message="Des programmes gratuits à télécharger et à utiliser directement dans Glift."
+          iconSrc="/icons/info_blue.svg"
+          iconHoverSrc="/icons/info_blue_hover.svg"
+          iconSize={18}
+          gapPx={12}
+          widthPx={220}
+          ariaLabel="Plus d’informations sur le Glift Store"
+        />
+      </span>
+    </li>
+    <li className="flex items-center gap-1">
+      <Image src="/icons/inclus.svg" alt="Check" width={30} height={30} />
+      <span className="inline-flex items-center gap-1">
+        <span className="font-bold text-[#3A416F]">Accès aux offres Premium de la Glift Shop</span>
+        <InfoAdornment
+          message="Une sélection d’offres régulièrement mise à jour correspondant à votre profil."
+          iconSrc="/icons/info_blue.svg"
+          iconHoverSrc="/icons/info_blue_hover.svg"
+          iconSize={18}
+          gapPx={12}
+          widthPx={220}
+          ariaLabel="Plus d’informations sur la Glift Shop"
+        />
+      </span>
+    </li>
     <li className="flex items-center gap-1"><Image src="/icons/inclus.svg" alt="Check" width={30} height={30} />Annulation gratuite à tout moment</li>
   </ul>
 

--- a/src/components/InfoAdornment.tsx
+++ b/src/components/InfoAdornment.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import Image from "next/image"
+import { createPortal } from "react-dom"
+
+type Props = {
+  message: string
+  iconSrc?: string
+  iconHoverSrc?: string
+  iconSize?: number
+  gapPx?: number
+  widthPx?: number
+  ariaLabel?: string
+}
+
+export default function InfoAdornment({
+  message,
+  iconSrc = "/icons/info_blue.svg",
+  iconHoverSrc = "/icons/info_blue_hover.svg",
+  iconSize = 18,
+  gapPx = 12,
+  widthPx = 220,
+  ariaLabel = "Plus d’informations",
+}: Props) {
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const tipRef = useRef<HTMLDivElement>(null)
+
+  const [overAnchor, setOverAnchor] = useState(false)
+  const [overTip, setOverTip] = useState(false)
+  const open = overAnchor || overTip
+
+  const [mounted, setMounted] = useState(false)
+  const [pos, setPos] = useState<{ top: number; left: number; side: "right" | "left" }>(() => ({
+    top: 0,
+    left: 0,
+    side: "right",
+  }))
+
+  const EDGE_PADDING = 8
+
+  const compute = useCallback(() => {
+    const el = anchorRef.current
+    if (!el) return
+
+    const rect = el.getBoundingClientRect()
+    const vw = window.innerWidth
+    const tipWidth = widthPx
+
+    let side: "right" | "left" = "right"
+    let left = rect.right + gapPx
+    if (left + tipWidth + EDGE_PADDING > vw) {
+      side = "left"
+      left = Math.max(EDGE_PADDING, rect.left - gapPx - tipWidth)
+    }
+
+    const top = Math.round(rect.top + rect.height / 2)
+    setPos({ top, left, side })
+  }, [gapPx, widthPx])
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    compute()
+
+    const onScroll = () => compute()
+    const onResize = () => compute()
+
+    const onPointerMove = (event: PointerEvent) => {
+      const x = event.clientX
+      const y = event.clientY
+      const anchorRect = anchorRef.current?.getBoundingClientRect()
+      const tipRect = tipRef.current?.getBoundingClientRect()
+
+      const inAnchor = !!anchorRect && x >= anchorRect.left && x <= anchorRect.right && y >= anchorRect.top && y <= anchorRect.bottom
+      const inTip = !!tipRect && x >= tipRect.left && x <= tipRect.right && y >= tipRect.top && y <= tipRect.bottom
+
+      setOverAnchor(inAnchor)
+      setOverTip(inTip)
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      const anchor = anchorRef.current
+      const tip = tipRef.current
+      if (anchor && anchor.contains(event.target as Node)) return
+      if (tip && tip.contains(event.target as Node)) return
+      setOverAnchor(false)
+      setOverTip(false)
+    }
+
+    const onWindowBlur = () => {
+      setOverAnchor(false)
+      setOverTip(false)
+    }
+
+    window.addEventListener("scroll", onScroll, true)
+    window.addEventListener("resize", onResize)
+    document.addEventListener("pointermove", onPointerMove, true)
+    document.addEventListener("pointerdown", onPointerDown, true)
+    window.addEventListener("blur", onWindowBlur)
+
+    return () => {
+      window.removeEventListener("scroll", onScroll, true)
+      window.removeEventListener("resize", onResize)
+      document.removeEventListener("pointermove", onPointerMove, true)
+      document.removeEventListener("pointerdown", onPointerDown, true)
+      window.removeEventListener("blur", onWindowBlur)
+    }
+  }, [compute, open])
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLSpanElement> = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      if (open) {
+        setOverAnchor(false)
+        setOverTip(false)
+      } else {
+        setOverAnchor(true)
+      }
+    } else if (event.key === "Escape") {
+      setOverAnchor(false)
+      setOverTip(false)
+    }
+  }
+
+  return (
+    <>
+      <span
+        ref={anchorRef}
+        className="relative inline-block select-none group"
+        style={{ width: iconSize, height: iconSize }}
+        onMouseEnter={() => setOverAnchor(true)}
+        onMouseLeave={() => setOverAnchor(false)}
+        onFocus={() => setOverAnchor(true)}
+        onBlur={() => setOverAnchor(false)}
+        onKeyDown={onKeyDown}
+        onClick={() => {
+          if (open) {
+            setOverAnchor(false)
+            setOverTip(false)
+          } else {
+            setOverAnchor(true)
+          }
+        }}
+        tabIndex={0}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+      >
+        <Image
+          src={iconSrc}
+          alt=""
+          width={iconSize}
+          height={iconSize}
+          className="block transition-opacity duration-150 ease-in-out group-hover:opacity-0"
+          style={{ opacity: open ? 0 : undefined }}
+        />
+        <Image
+          src={iconHoverSrc}
+          alt=""
+          width={iconSize}
+          height={iconSize}
+          className="absolute inset-0 opacity-0 transition-opacity duration-150 ease-in-out group-hover:opacity-100"
+          style={{ opacity: open ? 1 : undefined }}
+        />
+      </span>
+
+      {mounted && open && typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={tipRef}
+            className="fixed z-[10000] pointer-events-auto"
+            style={{ top: pos.top, left: pos.left, transform: "translateY(-50%)" }}
+            role="tooltip"
+            onMouseEnter={() => setOverTip(true)}
+            onMouseLeave={() => setOverTip(false)}
+          >
+            <div
+              className="relative bg-[#2F3247] text-white text-[14px] leading-snug font-medium px-3 py-2 rounded-[8px] shadow-[0_5px_21px_0_rgba(93,100,148,0.15)] break-words"
+              style={{ width: widthPx }}
+            >
+              {message}
+              {pos.side === "right" ? (
+                <span className="absolute left-[-8px] top-1/2 -translate-y-1/2 w-0 h-0 border-y-[8px] border-y-transparent border-r-[8px] border-r-[#2F3247]" />
+              ) : (
+                <span className="absolute right-[-8px] top-1/2 -translate-y-1/2 w-0 h-0 border-y-[8px] border-y-transparent border-l-[8px] border-l-[#2F3247]" />
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a reusable InfoAdornment tooltip component with configurable icons and messaging
- update the tarifs page to display Glift Store and Shop perks with blue info tooltips
- add the info_blue and info_blue_hover icons used by the new adornment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e541f777fc832e947771cf09222186