### PR TITLE
Ensure signup triggers verification email and banner display

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -38,6 +38,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: signupError.message }, { status: 400 });
     }
 
+    if (!signupData?.user?.email_confirmed_at) {
+      const { error: resendError } = await supabase.auth.resend({
+        type: "signup",
+        email,
+      });
+
+      if (resendError) {
+        console.error(
+          "Envoi initial de l'email de vérification impossible",
+          resendError,
+        );
+      }
+    }
+
     // 🔑 Connexion automatique juste après
     const { error: signinError } = await supabase.auth.signInWithPassword({
       email,

--- a/src/components/VerifyEmailBanner.tsx
+++ b/src/components/VerifyEmailBanner.tsx
@@ -86,15 +86,6 @@ export default function VerifyEmailBanner() {
       };
     }
 
-    if (user?.email_confirmed_at) {
-      setShow(false);
-      setDeadline(null);
-      setLoading(false);
-      return () => {
-        cancelled = true;
-      };
-    }
-
     const computeDeadline = (profile: ProfileRow | null): Date | null => {
       const metadataDeadline = parseISODate(
         (user?.user_metadata as Record<string, unknown> | undefined)?.
@@ -129,7 +120,8 @@ export default function VerifyEmailBanner() {
       }
 
       const profile = data as ProfileRow | null;
-      const isVerified = Boolean(profile?.email_verified);
+      const isVerified =
+        Boolean(profile?.email_verified) || Boolean(user?.email_confirmed_at);
 
       setShow(!isVerified);
 


### PR DESCRIPTION
## Summary
- resend the Supabase signup verification email when the user is not auto-confirmed
- rely on profile verification state to control the email reminder banner visibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e549ddff2c832e9c393dedcda4aa44